### PR TITLE
fix: align register/link request field names

### DIFF
--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -23,9 +23,9 @@ export const parseClaimCodeResponse = (input: unknown): ClaimCodeResponse =>
 
 export const registerRequestSchema = z.object({
   claimCode: nonEmptyStringSchema,
-  handle: nonEmptyStringSchema,
+  publicHandle: nonEmptyStringSchema,
   avatar: nonEmptyStringSchema,
-  agentName: nonEmptyStringSchema,
+  agentLabel: nonEmptyStringSchema,
 });
 export type RegisterRequest = z.infer<typeof registerRequestSchema>;
 export const parseRegisterRequest = (input: unknown): RegisterRequest =>
@@ -44,7 +44,7 @@ export const parseRegisterResponse = (input: unknown): RegisterResponse =>
 
 export const linkRequestSchema = z.object({
   ownerToken: ownerTokenSchema,
-  agentName: nonEmptyStringSchema,
+  agentLabel: nonEmptyStringSchema,
 });
 export type LinkRequest = z.infer<typeof linkRequestSchema>;
 export const parseLinkRequest = (input: unknown): LinkRequest =>

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -64,7 +64,7 @@ export const burnStartRequestSchema = z.object({
   ownerToken: ownerTokenSchema,
   provider: providerSchema,
   targetTokens: positiveTokenCountSchema,
-  presetId: presetIdSchema.optional(),
+  presetId: presetIdSchema.nullish(),
 });
 export type BurnStartRequest = z.infer<typeof burnStartRequestSchema>;
 export const parseBurnStartRequest = (input: unknown): BurnStartRequest =>

--- a/tests/unit/shared-api.test.ts
+++ b/tests/unit/shared-api.test.ts
@@ -115,6 +115,32 @@ describe("shared api contracts", () => {
       presetId: "tier-2",
     });
 
+    expect(
+      parseBurnStartRequest({
+        ownerToken: "tb_owner_123456",
+        provider: "anthropic",
+        targetTokens: 250_000,
+      }),
+    ).toMatchObject({
+      ownerToken: "tb_owner_123456",
+      provider: "anthropic",
+      targetTokens: 250_000,
+    });
+
+    expect(
+      parseBurnStartRequest({
+        ownerToken: "tb_owner_123456",
+        provider: "openai",
+        targetTokens: 125_000,
+        presetId: null,
+      }),
+    ).toMatchObject({
+      ownerToken: "tb_owner_123456",
+      provider: "openai",
+      targetTokens: 125_000,
+      presetId: null,
+    });
+
     expect(() =>
       parseBurnStartRequest({
         ownerToken: "tb_owner_123456",

--- a/tests/unit/shared-api.test.ts
+++ b/tests/unit/shared-api.test.ts
@@ -6,7 +6,9 @@ import {
   parseBurnStartRequest,
   parseClaimCodeResponse,
   parseHeartbeatRequest,
+  parseLinkRequest,
   parseLinkResponse,
+  parseRegisterRequest,
   parseRegisterResponse,
   parseTelemetryEventRequest,
   presetIdValues,
@@ -54,6 +56,48 @@ describe("shared api contracts", () => {
       handle: "burner",
       avatar: "🔥",
     });
+  });
+
+  it("validates register and link request payloads", () => {
+    expect(
+      parseRegisterRequest({
+        claimCode: "ABC123",
+        publicHandle: "burner",
+        avatar: "🔥",
+        agentLabel: "office-macbook",
+      }),
+    ).toMatchObject({
+      claimCode: "ABC123",
+      publicHandle: "burner",
+      avatar: "🔥",
+      agentLabel: "office-macbook",
+    });
+
+    expect(() =>
+      parseRegisterRequest({
+        claimCode: "ABC123",
+        handle: "burner",
+        avatar: "🔥",
+        agentName: "office-macbook",
+      }),
+    ).toThrow(/publicHandle|agentLabel/i);
+
+    expect(
+      parseLinkRequest({
+        ownerToken: "tb_owner_123456",
+        agentLabel: "travel-laptop",
+      }),
+    ).toMatchObject({
+      ownerToken: "tb_owner_123456",
+      agentLabel: "travel-laptop",
+    });
+
+    expect(() =>
+      parseLinkRequest({
+        ownerToken: "tb_owner_123456",
+        agentName: "travel-laptop",
+      }),
+    ).toThrow(/agentLabel/i);
   });
 
   it("validates burn start payloads", () => {


### PR DESCRIPTION
**@worker-01**

## Summary
- align the shared register request schema with the delivery plan fields `publicHandle` and `agentLabel`
- align the shared link request schema with the delivery plan field `agentLabel`
- allow burn-start requests to send `presetId: null` or omit `presetId`, matching the delivery-plan contract
- add focused unit coverage for the corrected register/link request payloads and nullable burn preset ids

## Verification
- `npm run test -- --run tests/unit/shared-api.test.ts`
- `npm run typecheck`

Closes #6
