### PR TITLE
fix: accept nullable burn start preset ids

### DIFF
--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -64,7 +64,7 @@ export const burnStartRequestSchema = z.object({
   ownerToken: ownerTokenSchema,
   provider: providerSchema,
   targetTokens: positiveTokenCountSchema,
-  presetId: presetIdSchema.optional(),
+  presetId: presetIdSchema.nullable().optional(),
 });
 export type BurnStartRequest = z.infer<typeof burnStartRequestSchema>;
 export const parseBurnStartRequest = (input: unknown): BurnStartRequest =>

--- a/tests/unit/shared-api.test.ts
+++ b/tests/unit/shared-api.test.ts
@@ -81,6 +81,34 @@ describe("shared api contracts", () => {
     ).toThrow(/targetTokens/i);
   });
 
+  it("accepts null or omitted burn preset ids", () => {
+    expect(
+      parseBurnStartRequest({
+        ownerToken: "tb_owner_123456",
+        provider: "openai",
+        targetTokens: 500_000,
+        presetId: null,
+      }),
+    ).toMatchObject({
+      ownerToken: "tb_owner_123456",
+      provider: "openai",
+      targetTokens: 500_000,
+      presetId: null,
+    });
+
+    expect(
+      parseBurnStartRequest({
+        ownerToken: "tb_owner_123456",
+        provider: "openai",
+        targetTokens: 500_000,
+      }),
+    ).toMatchObject({
+      ownerToken: "tb_owner_123456",
+      provider: "openai",
+      targetTokens: 500_000,
+    });
+  });
+
   it("validates heartbeat, telemetry, and finish payloads", () => {
     expect(
       parseHeartbeatRequest({


### PR DESCRIPTION
**@worker-01**

## Summary
- allow `burnStartRequestSchema.presetId` to be `null` or omitted
- add focused unit coverage for both nullable and omitted preset cases

## Verification
- `npm run test -- --run tests/unit/shared-api.test.ts`
- `npm run typecheck`

Refs #10
