### PR TITLE
feat: add site postgres schema foundation

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -10,13 +10,18 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@token-burner/shared": "file:../../packages/shared",
+    "drizzle-orm": "^0.44.7",
     "next": "16.2.4",
+    "pg": "^8.16.3",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/pg": "^8.15.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/apps/site/src/lib/db/client.ts
+++ b/apps/site/src/lib/db/client.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+import * as schema from "./schema";
+
+type TokenBurnerDatabase = NodePgDatabase<typeof schema>;
+
+type GlobalDatabaseCache = typeof globalThis & {
+  __tokenBurnerPool__?: Pool;
+  __tokenBurnerDb__?: TokenBurnerDatabase;
+};
+
+const globalCache = globalThis as GlobalDatabaseCache;
+
+export const getDatabaseUrl = (): string => {
+  const databaseUrl =
+    process.env.DATABASE_URL ?? process.env.DATABASE_URL_MIGRATIONS;
+
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+
+  throw new Error(
+    "Set DATABASE_URL or DATABASE_URL_MIGRATIONS before using the site database client.",
+  );
+};
+
+export const pool =
+  globalCache.__tokenBurnerPool__ ??
+  new Pool({
+    connectionString: getDatabaseUrl(),
+  });
+
+export const db =
+  globalCache.__tokenBurnerDb__ ?? drizzle({ client: pool, schema });
+
+if (process.env.NODE_ENV !== "production") {
+  globalCache.__tokenBurnerPool__ = pool;
+  globalCache.__tokenBurnerDb__ = db;
+}

--- a/apps/site/src/lib/db/schema.ts
+++ b/apps/site/src/lib/db/schema.ts
@@ -1,0 +1,154 @@
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  check,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { burnStatusValues, providerValues } from "@token-burner/shared";
+
+const providerValuesSql = sql.raw(
+  providerValues.map((provider) => `'${provider}'`).join(", "),
+);
+
+const activeBurnStatuses = burnStatusValues.filter(
+  (status): status is (typeof burnStatusValues)[number] =>
+    status === "queued" || status === "running" || status === "stopping",
+);
+
+const activeBurnStatusesSql = sql.raw(
+  activeBurnStatuses.map((status) => `'${status}'`).join(", "),
+);
+
+const burnStatusValuesSql = sql.raw(
+  burnStatusValues.map((status) => `'${status}'`).join(", "),
+);
+
+export const humans = pgTable(
+  "humans",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    publicHandle: text("public_handle").notNull(),
+    avatarUrl: text("avatar_url").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("humans_public_handle_idx").using(
+      "btree",
+      sql`lower(${table.publicHandle})`,
+    ),
+  ],
+);
+
+export const agentInstallations = pgTable("agent_installations", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  humanId: uuid("human_id")
+    .notNull()
+    .references(() => humans.id, { onDelete: "cascade" }),
+  agentLabel: text("agent_label").notNull(),
+  localMachineLabel: text("local_machine_label"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  lastSeenAt: timestamp("last_seen_at", { withTimezone: true }),
+});
+
+export const claimCodes = pgTable("claim_codes", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  code: text("code").notNull().unique(),
+  status: text("status").notNull().default("available"),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  claimedHumanId: uuid("claimed_human_id").references(() => humans.id, {
+    onDelete: "set null",
+  }),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
+export const ownerTokens = pgTable("owner_tokens", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  humanId: uuid("human_id")
+    .notNull()
+    .references(() => humans.id, { onDelete: "cascade" }),
+  tokenHash: text("token_hash").notNull().unique(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  revokedAt: timestamp("revoked_at", { withTimezone: true }),
+});
+
+export const burns = pgTable(
+  "burns",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    humanId: uuid("human_id")
+      .notNull()
+      .references(() => humans.id, { onDelete: "cascade" }),
+    agentInstallationId: uuid("agent_installation_id")
+      .notNull()
+      .references(() => agentInstallations.id, { onDelete: "cascade" }),
+    provider: text("provider", { enum: providerValues }).notNull(),
+    model: text("model").notNull(),
+    presetId: text("preset_id"),
+    requestedBilledTokenTarget: bigint("requested_billed_token_target", {
+      mode: "number",
+    }).notNull(),
+    billedTokensConsumed: bigint("billed_tokens_consumed", {
+      mode: "number",
+    })
+      .notNull()
+      .default(0),
+    status: text("status", { enum: burnStatusValues }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }),
+    finishedAt: timestamp("finished_at", { withTimezone: true }),
+    lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
+  },
+  (table) => [
+    check(
+      "burns_requested_billed_token_target_check",
+      sql`${table.requestedBilledTokenTarget} > 0`,
+    ),
+    check(
+      "burns_billed_tokens_consumed_check",
+      sql`${table.billedTokensConsumed} >= 0`,
+    ),
+    check(
+      "burns_provider_check",
+      sql`${table.provider} in (${providerValuesSql})`,
+    ),
+    check(
+      "burns_status_check",
+      sql`${table.status} in (${burnStatusValuesSql})`,
+    ),
+    uniqueIndex("burns_one_active_per_human_idx")
+      .on(table.humanId)
+      .where(sql`${table.status} in (${activeBurnStatusesSql})`),
+  ],
+);
+
+export const burnEvents = pgTable("burn_events", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  burnId: uuid("burn_id")
+    .notNull()
+    .references(() => burns.id, { onDelete: "cascade" }),
+  eventType: text("event_type").notNull(),
+  eventPayload: jsonb("event_payload")
+    .$type<Record<string, unknown>>()
+    .notNull()
+    .default(sql`'{}'::jsonb`),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});

--- a/drizzle/0001_initial.sql
+++ b/drizzle/0001_initial.sql
@@ -1,0 +1,66 @@
+create extension if not exists "pgcrypto";
+
+create table humans (
+  id uuid primary key default gen_random_uuid(),
+  public_handle text not null,
+  avatar_url text not null,
+  created_at timestamptz not null default now()
+);
+
+create table agent_installations (
+  id uuid primary key default gen_random_uuid(),
+  human_id uuid not null references humans(id) on delete cascade,
+  agent_label text not null,
+  local_machine_label text null,
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz null
+);
+
+create table claim_codes (
+  id uuid primary key default gen_random_uuid(),
+  code text not null unique,
+  status text not null default 'available',
+  expires_at timestamptz not null,
+  claimed_human_id uuid null references humans(id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+create table owner_tokens (
+  id uuid primary key default gen_random_uuid(),
+  human_id uuid not null references humans(id) on delete cascade,
+  token_hash text not null unique,
+  created_at timestamptz not null default now(),
+  last_used_at timestamptz null,
+  revoked_at timestamptz null
+);
+
+create table burns (
+  id uuid primary key default gen_random_uuid(),
+  human_id uuid not null references humans(id) on delete cascade,
+  agent_installation_id uuid not null references agent_installations(id) on delete cascade,
+  provider text not null check (provider in ('openai', 'anthropic')),
+  model text not null,
+  preset_id text null,
+  requested_billed_token_target bigint not null check (requested_billed_token_target > 0),
+  billed_tokens_consumed bigint not null default 0 check (billed_tokens_consumed >= 0),
+  status text not null check (status in ('queued', 'running', 'stopping', 'completed', 'interrupted', 'failed')),
+  created_at timestamptz not null default now(),
+  started_at timestamptz null,
+  finished_at timestamptz null,
+  last_heartbeat_at timestamptz null
+);
+
+create table burn_events (
+  id uuid primary key default gen_random_uuid(),
+  burn_id uuid not null references burns(id) on delete cascade,
+  event_type text not null,
+  event_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create unique index humans_public_handle_idx
+on humans (lower(public_handle));
+
+create unique index burns_one_active_per_human_idx
+on burns (human_id)
+where status in ('queued', 'running', 'stopping');

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,18 @@
       "name": "@token-burner/site",
       "version": "0.1.0",
       "dependencies": {
+        "@token-burner/shared": "file:../../packages/shared",
+        "drizzle-orm": "^0.44.7",
         "next": "16.2.4",
+        "pg": "^8.16.3",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/pg": "^8.15.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -5419,6 +5424,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -5609,6 +5636,131 @@
         "node": ">=6"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.44.7",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
+      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
@@ -5777,6 +5929,95 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5825,6 +6066,45 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -5870,6 +6150,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -5884,6 +6170,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -5987,6 +6282,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",
@@ -6174,6 +6476,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/tests/integration/db-schema.test.ts
+++ b/tests/integration/db-schema.test.ts
@@ -1,0 +1,88 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const readRepoFile = async (relativePath: string) =>
+  readFile(path.join(repoRoot, relativePath), "utf8");
+
+describe("database schema foundation", () => {
+  it("defines the six core tables and required burn columns in the Drizzle schema", async () => {
+    const schemaModule = await import("../../apps/site/src/lib/db/schema");
+
+    expect(schemaModule).toMatchObject({
+      humans: expect.anything(),
+      agentInstallations: expect.anything(),
+      claimCodes: expect.anything(),
+      ownerTokens: expect.anything(),
+      burns: expect.anything(),
+      burnEvents: expect.anything(),
+    });
+
+    expect(schemaModule.humans.publicHandle).toBeDefined();
+    expect(schemaModule.humans.avatarUrl).toBeDefined();
+    expect(schemaModule.agentInstallations.agentLabel).toBeDefined();
+    expect(schemaModule.claimCodes.code).toBeDefined();
+    expect(schemaModule.ownerTokens.tokenHash).toBeDefined();
+    expect(schemaModule.burns.provider).toBeDefined();
+    expect(schemaModule.burns.model).toBeDefined();
+    expect(schemaModule.burns.status).toBeDefined();
+    expect(schemaModule.burns.requestedBilledTokenTarget).toBeDefined();
+    expect(schemaModule.burns.billedTokensConsumed).toBeDefined();
+    expect(schemaModule.burns.lastHeartbeatAt).toBeDefined();
+    expect(schemaModule.burns.startedAt).toBeDefined();
+    expect(schemaModule.burns.finishedAt).toBeDefined();
+    expect(schemaModule.burnEvents.eventType).toBeDefined();
+    expect(schemaModule.burnEvents.eventPayload).toBeDefined();
+  });
+
+  it("keeps the site database client server-only and env-backed", async () => {
+    const clientSource = await readRepoFile("apps/site/src/lib/db/client.ts");
+
+    expect(clientSource).toContain('import "server-only"');
+    expect(clientSource).toMatch(/DATABASE_URL/);
+    expect(clientSource).toMatch(/DATABASE_URL_MIGRATIONS/);
+    expect(clientSource).toMatch(/drizzle-orm\/node-postgres/);
+    expect(clientSource).toMatch(/from "pg"/);
+  });
+
+  it("creates the required tables, burn columns, and uniqueness indexes in SQL", async () => {
+    const migrationSql = await readRepoFile("drizzle/0001_initial.sql");
+
+    for (const tableName of [
+      "humans",
+      "agent_installations",
+      "claim_codes",
+      "owner_tokens",
+      "burns",
+      "burn_events",
+    ]) {
+      expect(migrationSql).toMatch(
+        new RegExp(`create table\\s+\"?${tableName}\"?`, "i"),
+      );
+    }
+
+    expect(migrationSql).toMatch(
+      /requested_billed_token_target bigint not null check \(requested_billed_token_target > 0\)/i,
+    );
+    expect(migrationSql).toMatch(
+      /billed_tokens_consumed bigint not null default 0/i,
+    );
+    expect(migrationSql).toMatch(/provider text not null/i);
+    expect(migrationSql).toMatch(/model text not null/i);
+    expect(migrationSql).toMatch(/status text not null/i);
+    expect(migrationSql).toMatch(/last_heartbeat_at timestamptz null/i);
+    expect(migrationSql).toMatch(
+      /create unique index humans_public_handle_idx\s+on humans \(lower\(public_handle\)\)/i,
+    );
+    expect(migrationSql).toMatch(
+      /create unique index burns_one_active_per_human_idx\s+on burns \(human_id\)\s+where status in \('queued', 'running', 'stopping'\)/i,
+    );
+  });
+});


### PR DESCRIPTION
**@worker-01**

## Summary
- recreate the schema foundation change set on top of the current epic head
- keep the diff limited to the issue-8 schema foundation files and minimal package updates
- exclude the already-landed nullable `presetId` shared-contract change from the old PR #13 review surface

## Test Plan
- `npm run test -- --run tests/integration/db-schema.test.ts`
- `npm run typecheck`

## Notes
- This PR replaces conflicted PR #13 with a clean branch based on `epic/1-deliver-token-burner-v1`.
