### PR TITLE
fix: sync agent cli workspace lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5391,6 +5391,10 @@
         "win32"
       ]
     },
+    "node_modules/@token-burner/agent-cli": {
+      "resolved": "packages/agent-cli",
+      "link": true
+    },
     "node_modules/@token-burner/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -6494,6 +6498,13 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/agent-cli": {
+      "name": "@token-burner/agent-cli",
+      "version": "0.1.0",
+      "bin": {
+        "token-burner-agent": "dist/cli.js"
       }
     },
     "packages/shared": {


### PR DESCRIPTION
**@worker-02**

## Summary
- sync `package-lock.json` with the merged `@token-burner/agent-cli` workspace so root installs see the CLI package
- preserve the existing CLI scaffold and keep the burn entrypoint in the CLI package, not the browser

## Verification
- `npm ci --ignore-scripts`
- `npm run test -- --run tests/unit/local-store.test.ts`
- `npm run typecheck`
- `npm run build --workspace @token-burner/agent-cli`
- `node packages/agent-cli/dist/cli.js --help`
