### PR TITLE
feat: add public db read selectors

### DIFF
--- a/apps/site/src/lib/db/queries.ts
+++ b/apps/site/src/lib/db/queries.ts
@@ -1,0 +1,333 @@
+import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { type NodePgDatabase } from "drizzle-orm/node-postgres";
+
+import {
+  providerValues,
+  terminalBurnStatusValues,
+  type BurnStatus,
+  type ProviderId,
+} from "@token-burner/shared";
+
+import * as schema from "./schema";
+
+const { burns, humans } = schema;
+
+const dayInMilliseconds = 24 * 60 * 60 * 1000;
+const weekInMilliseconds = 7 * dayInMilliseconds;
+const activeBurnStatuses = ["queued", "running", "stopping"] as const;
+
+type TokenBurnerDatabase = NodePgDatabase<typeof schema>;
+
+type QueryOptions = {
+  database?: TokenBurnerDatabase;
+};
+
+type TimedQueryOptions = QueryOptions & {
+  now?: Date;
+  limit?: number;
+};
+
+type RecentBurnOptions = QueryOptions & {
+  recentBurnLimit?: number;
+};
+
+type LeaderboardRow = {
+  burnId: string;
+  humanId: string;
+  handle: string;
+  avatarUrl: string;
+  provider: ProviderId;
+  model: string;
+  requestedBilledTokenTarget: number;
+  billedTokensConsumed: number;
+  status: BurnStatus;
+  createdAt: Date;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+};
+
+type BurnSummaryRow = {
+  burnId: string;
+  provider: ProviderId;
+  model: string;
+  requestedBilledTokenTarget: number;
+  billedTokensConsumed: number;
+  status: BurnStatus;
+  createdAt: Date;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+};
+
+export type LeaderboardEntry = LeaderboardRow & {
+  rank: number;
+};
+
+export type ProviderSplitLeaderboard = Record<ProviderId, LeaderboardEntry[]>;
+
+export type LiveBurnFeedEntry = LeaderboardRow & {
+  lastHeartbeatAt: Date | null;
+};
+
+export type PublicProfileBurn = BurnSummaryRow;
+
+export type PublicProfile = {
+  humanId: string;
+  handle: string;
+  avatarUrl: string;
+  providerTotals: Record<ProviderId, number>;
+  recentBurns: PublicProfileBurn[];
+};
+
+export type PublicBurn = BurnSummaryRow & {
+  burnId: string;
+  humanId: string;
+  handle: string;
+  avatarUrl: string;
+};
+
+const createEmptyProviderRecord = <Value>(factory: () => Value): Record<
+  ProviderId,
+  Value
+> => ({
+  openai: factory(),
+  anthropic: factory(),
+});
+
+const normalizeNumericValue = (value: number | string | null | undefined) =>
+  value === null || value === undefined ? 0 : Number(value);
+
+const mapBurnSummary = (row: BurnSummaryRow): PublicProfileBurn => ({
+  burnId: row.burnId,
+  provider: row.provider,
+  model: row.model,
+  requestedBilledTokenTarget: row.requestedBilledTokenTarget,
+  billedTokensConsumed: row.billedTokensConsumed,
+  status: row.status,
+  createdAt: row.createdAt,
+  startedAt: row.startedAt,
+  finishedAt: row.finishedAt,
+});
+
+const resolveDatabase = async (
+  database?: TokenBurnerDatabase,
+): Promise<TokenBurnerDatabase> => {
+  if (database) {
+    return database;
+  }
+
+  const client = await import("./client");
+  return client.db;
+};
+
+const getWindowStart = (windowSizeInMilliseconds: number, now: Date) =>
+  new Date(now.getTime() - windowSizeInMilliseconds);
+
+const mapLeaderboardRows = (
+  rows: LeaderboardRow[],
+  limit: number,
+): ProviderSplitLeaderboard => {
+  const splitResults = createEmptyProviderRecord<LeaderboardEntry[]>(() => []);
+
+  for (const provider of providerValues) {
+    const providerRows = rows.filter((row) => row.provider === provider);
+
+    splitResults[provider] = providerRows.slice(0, limit).map((row, index) => ({
+      ...row,
+      rank: index + 1,
+    }));
+  }
+
+  return splitResults;
+};
+
+const getProviderLeaderboard = async ({
+  database,
+  limit = 10,
+  now,
+  windowStart,
+}: TimedQueryOptions & {
+  windowStart?: Date;
+}): Promise<ProviderSplitLeaderboard> => {
+  const queryDatabase = await resolveDatabase(database);
+  const conditions = [inArray(burns.status, terminalBurnStatusValues)];
+
+  if (windowStart) {
+    conditions.push(gte(burns.createdAt, windowStart));
+  }
+
+  const rows = await queryDatabase
+    .select({
+      burnId: burns.id,
+      humanId: humans.id,
+      handle: humans.publicHandle,
+      avatarUrl: humans.avatarUrl,
+      provider: burns.provider,
+      model: burns.model,
+      requestedBilledTokenTarget: burns.requestedBilledTokenTarget,
+      billedTokensConsumed: burns.billedTokensConsumed,
+      status: burns.status,
+      createdAt: burns.createdAt,
+      startedAt: burns.startedAt,
+      finishedAt: burns.finishedAt,
+    })
+    .from(burns)
+    .innerJoin(humans, eq(burns.humanId, humans.id))
+    .where(and(...conditions))
+    .orderBy(desc(burns.billedTokensConsumed), desc(burns.createdAt));
+
+  return mapLeaderboardRows(rows, limit);
+};
+
+export const getProviderDailyLeaderboard = async ({
+  now = new Date(),
+  ...options
+}: TimedQueryOptions = {}): Promise<ProviderSplitLeaderboard> =>
+  getProviderLeaderboard({
+    ...options,
+    now,
+    windowStart: getWindowStart(dayInMilliseconds, now),
+  });
+
+export const getProviderWeeklyLeaderboard = async ({
+  now = new Date(),
+  ...options
+}: TimedQueryOptions = {}): Promise<ProviderSplitLeaderboard> =>
+  getProviderLeaderboard({
+    ...options,
+    now,
+    windowStart: getWindowStart(weekInMilliseconds, now),
+  });
+
+export const getProviderAllTimeLeaderboard = async (
+  options: QueryOptions & {
+    limit?: number;
+  } = {},
+): Promise<ProviderSplitLeaderboard> => getProviderLeaderboard(options);
+
+export const getLiveBurnFeed = async ({
+  database,
+  limit = 10,
+}: TimedQueryOptions = {}): Promise<LiveBurnFeedEntry[]> => {
+  const queryDatabase = await resolveDatabase(database);
+
+  const rows = await queryDatabase
+    .select({
+      burnId: burns.id,
+      humanId: humans.id,
+      handle: humans.publicHandle,
+      avatarUrl: humans.avatarUrl,
+      provider: burns.provider,
+      model: burns.model,
+      requestedBilledTokenTarget: burns.requestedBilledTokenTarget,
+      billedTokensConsumed: burns.billedTokensConsumed,
+      status: burns.status,
+      createdAt: burns.createdAt,
+      startedAt: burns.startedAt,
+      finishedAt: burns.finishedAt,
+      lastHeartbeatAt: burns.lastHeartbeatAt,
+    })
+    .from(burns)
+    .innerJoin(humans, eq(burns.humanId, humans.id))
+    .where(inArray(burns.status, activeBurnStatuses))
+    .orderBy(desc(burns.lastHeartbeatAt), desc(burns.createdAt))
+    .limit(limit);
+
+  return rows;
+};
+
+export const getPublicProfileByHandle = async (
+  handle: string,
+  { database, recentBurnLimit = 10 }: RecentBurnOptions = {},
+): Promise<PublicProfile | null> => {
+  const normalizedHandle = handle.trim().toLowerCase();
+
+  if (!normalizedHandle) {
+    return null;
+  }
+
+  const queryDatabase = await resolveDatabase(database);
+
+  const [humanRecord] = await queryDatabase
+    .select({
+      humanId: humans.id,
+      handle: humans.publicHandle,
+      avatarUrl: humans.avatarUrl,
+    })
+    .from(humans)
+    .where(sql`lower(${humans.publicHandle}) = ${normalizedHandle}`)
+    .limit(1);
+
+  if (!humanRecord) {
+    return null;
+  }
+
+  const [recentBurns, providerTotalsRows] = await Promise.all([
+    queryDatabase
+      .select({
+        burnId: burns.id,
+        provider: burns.provider,
+        model: burns.model,
+        requestedBilledTokenTarget: burns.requestedBilledTokenTarget,
+        billedTokensConsumed: burns.billedTokensConsumed,
+        status: burns.status,
+        createdAt: burns.createdAt,
+        startedAt: burns.startedAt,
+        finishedAt: burns.finishedAt,
+      })
+      .from(burns)
+      .where(eq(burns.humanId, humanRecord.humanId))
+      .orderBy(desc(burns.createdAt))
+      .limit(recentBurnLimit),
+    queryDatabase
+      .select({
+        provider: burns.provider,
+        totalBilledTokens: sql<string>`coalesce(sum(${burns.billedTokensConsumed}), 0)`,
+      })
+      .from(burns)
+      .where(eq(burns.humanId, humanRecord.humanId))
+      .groupBy(burns.provider),
+  ]);
+
+  const providerTotals = createEmptyProviderRecord<number>(() => 0);
+
+  for (const row of providerTotalsRows) {
+    providerTotals[row.provider] = normalizeNumericValue(row.totalBilledTokens);
+  }
+
+  return {
+    humanId: humanRecord.humanId,
+    handle: humanRecord.handle,
+    avatarUrl: humanRecord.avatarUrl,
+    providerTotals,
+    recentBurns: recentBurns.map(mapBurnSummary),
+  };
+};
+
+export const getPublicBurnById = async (
+  burnId: string,
+  { database }: QueryOptions = {},
+): Promise<PublicBurn | null> => {
+  const queryDatabase = await resolveDatabase(database);
+
+  const [row] = await queryDatabase
+    .select({
+      burnId: burns.id,
+      humanId: humans.id,
+      handle: humans.publicHandle,
+      avatarUrl: humans.avatarUrl,
+      provider: burns.provider,
+      model: burns.model,
+      requestedBilledTokenTarget: burns.requestedBilledTokenTarget,
+      billedTokensConsumed: burns.billedTokensConsumed,
+      status: burns.status,
+      createdAt: burns.createdAt,
+      startedAt: burns.startedAt,
+      finishedAt: burns.finishedAt,
+    })
+    .from(burns)
+    .innerJoin(humans, eq(burns.humanId, humans.id))
+    .where(eq(burns.id, burnId))
+    .limit(1);
+
+  return row ?? null;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "pg-mem": "^3.0.14",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
@@ -1384,50 +1385,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "apps/site/node_modules/call-bind": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/site/node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/site/node_modules/call-bound": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/site/node_modules/callsites": {
       "version": "3.1.0",
       "dev": true,
@@ -1575,22 +1532,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "apps/site/node_modules/define-data-property": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/site/node_modules/define-properties": {
       "version": "1.2.1",
       "dev": true,
@@ -1624,19 +1565,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "apps/site/node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "apps/site/node_modules/electron-to-chromium": {
@@ -1728,22 +1656,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "apps/site/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/site/node_modules/es-errors": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "apps/site/node_modules/es-iterator-helpers": {
       "version": "1.3.2",
       "dev": true,
@@ -1765,17 +1677,6 @@
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
         "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/site/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2324,14 +2225,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "apps/site/node_modules/function-bind": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/site/node_modules/function.prototype.name": {
       "version": "1.1.8",
       "dev": true,
@@ -2373,41 +2266,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "apps/site/node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/site/node_modules/get-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "apps/site/node_modules/get-symbol-description": {
@@ -2474,17 +2332,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "apps/site/node_modules/gopd": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/site/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -2509,17 +2356,6 @@
         "node": ">=8"
       }
     },
-    "apps/site/node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/site/node_modules/has-proto": {
       "version": "1.2.0",
       "dev": true,
@@ -2527,17 +2363,6 @@
       "dependencies": {
         "dunder-proto": "^1.0.0"
       },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/site/node_modules/has-symbols": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2557,17 +2382,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/site/node_modules/hasown": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "apps/site/node_modules/hermes-estree": {
@@ -2988,11 +2802,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "apps/site/node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "apps/site/node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -3210,14 +3019,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "apps/site/node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "apps/site/node_modules/merge2": {
       "version": "1.4.1",
       "dev": true,
@@ -3392,14 +3193,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/site/node_modules/object-keys": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "apps/site/node_modules/object.assign": {
@@ -3828,22 +3621,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "apps/site/node_modules/set-function-length": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "apps/site/node_modules/set-function-name": {
@@ -5585,6 +5362,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -5611,6 +5438,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5639,6 +5473,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/drizzle-orm": {
       "version": "0.44.7",
@@ -5765,12 +5624,60 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -5867,6 +5774,128 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -5874,12 +5903,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5890,6 +5962,33 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5914,6 +6013,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/pathe": {
@@ -5982,6 +6124,65 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-mem": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.14.tgz",
+      "integrity": "sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.2"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
@@ -6020,6 +6221,17 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.2.tgz",
+      "integrity": "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/picocolors": {
@@ -6109,6 +6321,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -6159,6 +6402,24 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -6490,6 +6751,13 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "pg-mem": "^3.0.14",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }

--- a/tests/integration/db-queries.test.ts
+++ b/tests/integration/db-queries.test.ts
@@ -1,0 +1,464 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { DataType, newDb } from "pg-mem";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getLiveBurnFeed,
+  getProviderAllTimeLeaderboard,
+  getProviderDailyLeaderboard,
+  getProviderWeeklyLeaderboard,
+  getPublicBurnById,
+  getPublicProfileByHandle,
+} from "../../apps/site/src/lib/db/queries";
+import * as schema from "../../apps/site/src/lib/db/schema";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const migrationPath = path.join(repoRoot, "drizzle/0001_initial.sql");
+const fixedNow = new Date("2026-04-21T12:00:00.000Z");
+
+const activeStatuses = ["queued", "running", "stopping"] as const;
+
+type TestDatabase = ReturnType<typeof drizzle<typeof schema>>;
+
+type TestContext = {
+  database: TestDatabase;
+  pool: { end: () => Promise<void> };
+};
+
+type HumanSeed = {
+  humanId: string;
+  installationId: string;
+};
+
+type BurnSeed = {
+  burnId: string;
+};
+
+const openPools: Array<{ end: () => Promise<void> }> = [];
+
+const createTestDatabase = async (): Promise<TestContext> => {
+  const memoryDatabase = newDb({ autoCreateForeignKeyIndices: true });
+  memoryDatabase.public.registerFunction({
+    name: "gen_random_uuid",
+    returns: DataType.uuid,
+    implementation: randomUUID,
+  });
+
+  const migrationSql = await readFile(migrationPath, "utf8");
+  memoryDatabase.public.none(
+    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n/i, ""),
+  );
+
+  const adapter = memoryDatabase.adapters.createPg();
+  const patchPgMemAdapter = (PgClass: {
+    prototype: {
+      adaptQuery: (query: unknown, values?: unknown[]) => unknown;
+      adaptResults: (query: unknown, results: {
+        rows: Array<Record<string, unknown>>;
+        fields: Array<{ name: string }>;
+      }) => unknown;
+    };
+  }) => {
+    const originalAdaptQuery = PgClass.prototype.adaptQuery;
+    const originalAdaptResults = PgClass.prototype.adaptResults;
+
+    PgClass.prototype.adaptQuery = function adaptQueryWithoutDriverTypes(
+      query,
+      values,
+    ) {
+      if (typeof query === "string") {
+        return originalAdaptQuery.call(this, query, values);
+      }
+
+      const sanitizedQuery =
+        query && typeof query === "object"
+          ? { ...(query as Record<string, unknown>) }
+          : query;
+
+      if (sanitizedQuery && typeof sanitizedQuery === "object") {
+        delete sanitizedQuery.types;
+      }
+
+      return originalAdaptQuery.call(this, sanitizedQuery, values);
+    };
+
+    PgClass.prototype.adaptResults = function adaptArrayRowMode(query, results) {
+      if (
+        query &&
+        typeof query === "object" &&
+        "rowMode" in (query as Record<string, unknown>) &&
+        (query as Record<string, unknown>).rowMode === "array"
+      ) {
+        return {
+          ...results,
+          rows: results.rows.map((row) =>
+            results.fields.map((field) => row[field.name]),
+          ),
+          fields: results.fields,
+        };
+      }
+
+      return originalAdaptResults.call(this, query, results);
+    };
+  };
+
+  patchPgMemAdapter(adapter.Pool);
+  patchPgMemAdapter(adapter.Client);
+
+  const pool = new adapter.Pool();
+  const database = drizzle({ client: pool, schema });
+
+  openPools.push(pool);
+
+  return { database, pool };
+};
+
+const seedHuman = async (
+  database: TestDatabase,
+  {
+    humanId = randomUUID(),
+    installationId = randomUUID(),
+    handle,
+    avatarUrl,
+  }: {
+    humanId?: string;
+    installationId?: string;
+    handle: string;
+    avatarUrl: string;
+  },
+): Promise<HumanSeed> => {
+  await database.insert(schema.humans).values({
+    id: humanId,
+    publicHandle: handle,
+    avatarUrl,
+    createdAt: fixedNow,
+  });
+
+  await database.insert(schema.agentInstallations).values({
+    id: installationId,
+    humanId,
+    agentLabel: `${handle}-agent`,
+    createdAt: fixedNow,
+    lastSeenAt: fixedNow,
+  });
+
+  return { humanId, installationId };
+};
+
+const seedBurn = async (
+  database: TestDatabase,
+  {
+    burnId = randomUUID(),
+    humanId,
+    installationId,
+    provider,
+    model = provider === "openai" ? "gpt-5.4" : "claude-opus-4.1",
+    status,
+    billedTokensConsumed,
+    requestedBilledTokenTarget = billedTokensConsumed + 100,
+    createdAt,
+    startedAt = createdAt,
+    finishedAt = activeStatuses.includes(status)
+      ? null
+      : new Date(createdAt.getTime() + 60_000),
+    lastHeartbeatAt = activeStatuses.includes(status) ? fixedNow : createdAt,
+  }: {
+    burnId?: string;
+    humanId: string;
+    installationId: string;
+    provider: "openai" | "anthropic";
+    model?: string;
+    status: (typeof schema.burns.$inferInsert)["status"];
+    billedTokensConsumed: number;
+    requestedBilledTokenTarget?: number;
+    createdAt: Date;
+    startedAt?: Date | null;
+    finishedAt?: Date | null;
+    lastHeartbeatAt?: Date | null;
+  },
+): Promise<BurnSeed> => {
+  await database.insert(schema.burns).values({
+    id: burnId,
+    humanId,
+    agentInstallationId: installationId,
+    provider,
+    model,
+    requestedBilledTokenTarget,
+    billedTokensConsumed,
+    status,
+    createdAt,
+    startedAt,
+    finishedAt,
+    lastHeartbeatAt,
+  });
+
+  return { burnId };
+};
+
+afterEach(async () => {
+  while (openPools.length > 0) {
+    const pool = openPools.pop();
+
+    if (pool) {
+      await pool.end();
+    }
+  }
+});
+
+describe("database query layer", () => {
+  it("keeps provider leaderboards split and applies daily and weekly time windows", async () => {
+    const { database } = await createTestDatabase();
+
+    const alice = await seedHuman(database, {
+      handle: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+    });
+    const bob = await seedHuman(database, {
+      handle: "Bob",
+      avatarUrl: "https://example.com/bob.png",
+    });
+    const chloe = await seedHuman(database, {
+      handle: "Chloe",
+      avatarUrl: "https://example.com/chloe.png",
+    });
+
+    const openaiDaily = await seedBurn(database, {
+      ...alice,
+      provider: "openai",
+      status: "completed",
+      billedTokensConsumed: 600,
+      createdAt: new Date("2026-04-21T10:00:00.000Z"),
+    });
+    const openaiWeekly = await seedBurn(database, {
+      ...bob,
+      provider: "openai",
+      status: "interrupted",
+      billedTokensConsumed: 800,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+    });
+    await seedBurn(database, {
+      ...chloe,
+      provider: "openai",
+      status: "failed",
+      billedTokensConsumed: 1_200,
+      createdAt: new Date("2026-04-10T08:00:00.000Z"),
+    });
+    const anthropicDaily = await seedBurn(database, {
+      ...chloe,
+      provider: "anthropic",
+      status: "completed",
+      billedTokensConsumed: 900,
+      createdAt: new Date("2026-04-21T09:00:00.000Z"),
+    });
+    const anthropicWeekly = await seedBurn(database, {
+      ...alice,
+      provider: "anthropic",
+      status: "completed",
+      billedTokensConsumed: 500,
+      createdAt: new Date("2026-04-19T09:00:00.000Z"),
+    });
+    await seedBurn(database, {
+      ...bob,
+      provider: "anthropic",
+      status: "running",
+      billedTokensConsumed: 999,
+      createdAt: new Date("2026-04-21T11:00:00.000Z"),
+    });
+
+    const daily = await getProviderDailyLeaderboard({
+      database,
+      now: fixedNow,
+    });
+    const weekly = await getProviderWeeklyLeaderboard({
+      database,
+      now: fixedNow,
+    });
+    const allTime = await getProviderAllTimeLeaderboard({
+      database,
+    });
+
+    expect(daily.openai.map((entry) => entry.burnId)).toEqual([openaiDaily.burnId]);
+    expect(daily.anthropic.map((entry) => entry.burnId)).toEqual([
+      anthropicDaily.burnId,
+    ]);
+
+    expect(weekly.openai.map((entry) => entry.burnId)).toEqual([
+      openaiWeekly.burnId,
+      openaiDaily.burnId,
+    ]);
+    expect(weekly.anthropic.map((entry) => entry.burnId)).toEqual([
+      anthropicDaily.burnId,
+      anthropicWeekly.burnId,
+    ]);
+
+    expect(allTime.openai.map((entry) => entry.provider)).toEqual([
+      "openai",
+      "openai",
+      "openai",
+    ]);
+    expect(allTime.anthropic.map((entry) => entry.provider)).toEqual([
+      "anthropic",
+      "anthropic",
+    ]);
+  });
+
+  it("returns only active burns in the live feed", async () => {
+    const { database } = await createTestDatabase();
+
+    const alice = await seedHuman(database, {
+      handle: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+    });
+    const bob = await seedHuman(database, {
+      handle: "Bob",
+      avatarUrl: "https://example.com/bob.png",
+    });
+
+    const runningBurn = await seedBurn(database, {
+      ...alice,
+      provider: "openai",
+      status: "running",
+      billedTokensConsumed: 320,
+      requestedBilledTokenTarget: 1_000,
+      createdAt: new Date("2026-04-21T10:00:00.000Z"),
+      lastHeartbeatAt: new Date("2026-04-21T11:58:00.000Z"),
+    });
+    await seedBurn(database, {
+      ...alice,
+      provider: "openai",
+      status: "completed",
+      billedTokensConsumed: 700,
+      createdAt: new Date("2026-04-20T10:00:00.000Z"),
+    });
+    const queuedBurn = await seedBurn(database, {
+      ...bob,
+      provider: "anthropic",
+      status: "queued",
+      billedTokensConsumed: 0,
+      requestedBilledTokenTarget: 2_000,
+      createdAt: new Date("2026-04-21T11:00:00.000Z"),
+      startedAt: null,
+      lastHeartbeatAt: new Date("2026-04-21T11:59:00.000Z"),
+    });
+
+    const liveFeed = await getLiveBurnFeed({ database });
+
+    expect(liveFeed.map((entry) => entry.burnId)).toEqual([
+      queuedBurn.burnId,
+      runningBurn.burnId,
+    ]);
+    expect(liveFeed.every((entry) => activeStatuses.includes(entry.status))).toBe(
+      true,
+    );
+    expect(liveFeed[0]).toMatchObject({
+      handle: "Bob",
+      provider: "anthropic",
+      model: "claude-opus-4.1",
+      requestedBilledTokenTarget: 2_000,
+      billedTokensConsumed: 0,
+      status: "queued",
+    });
+    expect(liveFeed[0]).not.toHaveProperty("eventPayload");
+  });
+
+  it("looks up public profiles case-insensitively and returns provider totals plus recent burns", async () => {
+    const { database } = await createTestDatabase();
+
+    const alice = await seedHuman(database, {
+      handle: "ALICE",
+      avatarUrl: "https://example.com/alice.png",
+    });
+
+    const newestBurn = await seedBurn(database, {
+      ...alice,
+      provider: "anthropic",
+      status: "running",
+      billedTokensConsumed: 350,
+      requestedBilledTokenTarget: 1_200,
+      createdAt: new Date("2026-04-21T11:00:00.000Z"),
+      lastHeartbeatAt: new Date("2026-04-21T11:59:00.000Z"),
+    });
+    await seedBurn(database, {
+      ...alice,
+      provider: "openai",
+      status: "completed",
+      billedTokensConsumed: 800,
+      createdAt: new Date("2026-04-20T11:00:00.000Z"),
+    });
+    await seedBurn(database, {
+      ...alice,
+      provider: "openai",
+      status: "failed",
+      billedTokensConsumed: 120,
+      createdAt: new Date("2026-04-18T11:00:00.000Z"),
+    });
+
+    const profile = await getPublicProfileByHandle("alice", { database });
+
+    expect(profile).toMatchObject({
+      handle: "ALICE",
+      avatarUrl: "https://example.com/alice.png",
+      providerTotals: {
+        openai: 920,
+        anthropic: 350,
+      },
+    });
+    expect(profile?.recentBurns[0]).toMatchObject({
+      burnId: newestBurn.burnId,
+      provider: "anthropic",
+      status: "running",
+      billedTokensConsumed: 350,
+    });
+    expect(profile?.recentBurns).toHaveLength(3);
+
+    await expect(
+      getPublicProfileByHandle("missing-handle", { database }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns public burn records by id and null for unknown ids", async () => {
+    const { database } = await createTestDatabase();
+
+    const alice = await seedHuman(database, {
+      handle: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+    });
+
+    const burn = await seedBurn(database, {
+      ...alice,
+      provider: "openai",
+      model: "gpt-5.4",
+      status: "completed",
+      billedTokensConsumed: 1_024,
+      requestedBilledTokenTarget: 1_500,
+      createdAt: new Date("2026-04-21T07:00:00.000Z"),
+      finishedAt: new Date("2026-04-21T07:15:00.000Z"),
+    });
+
+    const publicBurn = await getPublicBurnById(burn.burnId, { database });
+
+    expect(publicBurn).toMatchObject({
+      burnId: burn.burnId,
+      handle: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+      provider: "openai",
+      model: "gpt-5.4",
+      requestedBilledTokenTarget: 1_500,
+      billedTokensConsumed: 1_024,
+      status: "completed",
+    });
+
+    await expect(
+      getPublicBurnById("00000000-0000-0000-0000-000000000000", { database }),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
**@worker-03**

## Summary
- add server-side read selectors for provider-split daily, weekly, and all-time leaderboards
- add live-burn feed, public profile lookup, and public burn lookup helpers in `apps/site/src/lib/db/queries.ts`
- add integration coverage with an in-memory Postgres harness for selector behavior and null-safe lookups

## Verification
- `npm run test -- --run tests/integration`
- `npm run typecheck`
