### PR TITLE
fix: handle stale pre-heartbeat burns in housekeeping

### DIFF
--- a/apps/site/src/lib/server/housekeeping.ts
+++ b/apps/site/src/lib/server/housekeeping.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, inArray, lte } from "drizzle-orm";
+import { and, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import { type NodePgDatabase } from "drizzle-orm/node-postgres";
 
 import { type BurnStatus } from "@token-burner/shared";
@@ -41,6 +41,8 @@ const activeBurnSelection = {
   finishedAt: schema.burns.finishedAt,
   lastHeartbeatAt: schema.burns.lastHeartbeatAt,
 };
+
+const activeBurnTimestampFallback = sql<Date>`coalesce(${schema.burns.lastHeartbeatAt}, ${schema.burns.startedAt}, ${schema.burns.createdAt})`;
 
 const resolveDatabase = async (
   database?: TokenBurnerDatabase,
@@ -87,7 +89,7 @@ export const interruptStaleBurns = async ({
       and(
         eq(schema.burns.humanId, humanId),
         inArray(schema.burns.status, activeBurnStatuses),
-        lte(schema.burns.lastHeartbeatAt, staleCutoff),
+        lte(activeBurnTimestampFallback, staleCutoff),
       ),
     )
     .returning(activeBurnSelection);

--- a/tests/integration/server-auth-housekeeping.test.ts
+++ b/tests/integration/server-auth-housekeeping.test.ts
@@ -423,6 +423,104 @@ describe("server auth and housekeeping helpers", () => {
     });
   });
 
+  it("interrupts a stale queued burn that never heartbeated before allowing a replacement burn", async () => {
+    const { database } = await createTestDatabase();
+    const human = await seedHuman(database, {
+      handle: "eve",
+      avatarUrl: "https://example.com/eve.png",
+    });
+
+    const staleBurn = await seedBurn(database, {
+      ...human,
+      status: "queued",
+      createdAt: new Date("2026-04-21T11:50:00.000Z"),
+      startedAt: null,
+      lastHeartbeatAt: null,
+    });
+
+    const { ensureNoActiveBurnConflict } = await import(
+      "../../apps/site/src/lib/server/housekeeping"
+    );
+
+    await expect(
+      ensureNoActiveBurnConflict({
+        humanId: human.humanId,
+        database,
+        now: fixedNow,
+      }),
+    ).resolves.toBeUndefined();
+
+    const [interruptedBurn] = await database
+      .select({
+        status: schema.burns.status,
+        finishedAt: schema.burns.finishedAt,
+      })
+      .from(schema.burns)
+      .where(eq(schema.burns.id, staleBurn.burnId));
+
+    expect(interruptedBurn).toMatchObject({
+      status: "interrupted",
+      finishedAt: fixedNow,
+    });
+
+    await expect(
+      seedBurn(database, {
+        ...human,
+        status: "running",
+        createdAt: fixedNow,
+        lastHeartbeatAt: fixedNow,
+      }),
+    ).resolves.toMatchObject({
+      burnId: expect.any(String),
+    });
+  });
+
+  it("keeps a recently started running burn without heartbeats active", async () => {
+    const { database } = await createTestDatabase();
+    const human = await seedHuman(database, {
+      handle: "finn",
+      avatarUrl: "https://example.com/finn.png",
+    });
+
+    const freshStartedAt = new Date("2026-04-21T11:58:30.000Z");
+    const freshBurn = await seedBurn(database, {
+      ...human,
+      status: "running",
+      createdAt: new Date("2026-04-21T11:40:00.000Z"),
+      startedAt: freshStartedAt,
+      lastHeartbeatAt: null,
+    });
+
+    const { ensureNoActiveBurnConflict } = await import(
+      "../../apps/site/src/lib/server/housekeeping"
+    );
+
+    await expect(
+      ensureNoActiveBurnConflict({
+        humanId: human.humanId,
+        database,
+        now: fixedNow,
+      }),
+    ).rejects.toThrow(/active burn/i);
+
+    const [activeBurn] = await database
+      .select({
+        status: schema.burns.status,
+        startedAt: schema.burns.startedAt,
+        finishedAt: schema.burns.finishedAt,
+        lastHeartbeatAt: schema.burns.lastHeartbeatAt,
+      })
+      .from(schema.burns)
+      .where(eq(schema.burns.id, freshBurn.burnId));
+
+    expect(activeBurn).toMatchObject({
+      status: "running",
+      startedAt: freshStartedAt,
+      finishedAt: null,
+      lastHeartbeatAt: null,
+    });
+  });
+
   it("rejects a second non-stale active burn for the same human", async () => {
     const { database } = await createTestDatabase();
     const human = await seedHuman(database, {


### PR DESCRIPTION
**@worker-03**

## Summary
- age active burns using a lastHeartbeatAt -> startedAt -> createdAt fallback
- add integration coverage for stale queued burns and fresh no-heartbeat burns

## Testing
- `npm run test -- --run tests/integration/server-auth-housekeeping.test.ts`
- `npm run typecheck`
