### PR TITLE
fix: unblock vercel build + record real prod url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ DATABASE_URL="postgresql://postgres.avvhkermwadxttzpplmi:[YOUR-SUPABASE-DB-PASSW
 DATABASE_URL_MIGRATIONS="postgresql://postgres.avvhkermwadxttzpplmi:[YOUR-SUPABASE-DB-PASSWORD]@aws-1-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require"
 
 # Public web origin
-NEXT_PUBLIC_APP_URL="https://token-burner.vercel.app"
-TOKEN_BURNER_BASE_URL="https://token-burner.vercel.app"
+NEXT_PUBLIC_APP_URL="https://token-burner-seven.vercel.app"
+TOKEN_BURNER_BASE_URL="https://token-burner-seven.vercel.app"
 
 # 32-byte secret used to hash reusable owner tokens server-side
 OWNER_TOKEN_HASH_SECRET="replace-with-a-64-char-hex-secret"

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -28,5 +28,11 @@
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-gnu": "*",
+    "lightningcss-linux-arm64-gnu": "*",
+    "lightningcss-darwin-x64": "*",
+    "lightningcss-darwin-arm64": "*"
   }
 }

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -33,6 +33,10 @@
     "lightningcss-linux-x64-gnu": "*",
     "lightningcss-linux-arm64-gnu": "*",
     "lightningcss-darwin-x64": "*",
-    "lightningcss-darwin-arm64": "*"
+    "lightningcss-darwin-arm64": "*",
+    "@tailwindcss/oxide-linux-x64-gnu": "*",
+    "@tailwindcss/oxide-linux-arm64-gnu": "*",
+    "@tailwindcss/oxide-darwin-x64": "*",
+    "@tailwindcss/oxide-darwin-arm64": "*"
   }
 }

--- a/docs/ops/INFRASTRUCTURE.md
+++ b/docs/ops/INFRASTRUCTURE.md
@@ -29,7 +29,11 @@ CLI package
 - Owner team: `dylan-slateceos-projects`
 - Project name: `token-burner`
 - Project ID: `prj_sqXmugnqbPNHSkiCmwxN2e7KKh0B`
-- Created from: `/Users/dylanvu/token-burner/apps/site`
+- Root directory (server-side): `apps/site`
+- Framework: `nextjs`
+- Install command: `cd ../.. && npm install`
+- Vercel link file lives at repo root `.vercel/project.json`
+- Production URL: `https://token-burner-seven.vercel.app` (the plain `token-burner.vercel.app` subdomain is owned by another project)
 
 Useful commands:
 
@@ -42,7 +46,6 @@ npx vercel link --yes --project token-burner --scope dylan-slateceos-projects
 Notes:
 
 - `.vercel/project.json` is local-only metadata and stays uncommitted.
-- Production URL should eventually resolve at `https://token-burner.vercel.app` unless a custom domain replaces it.
 
 ## Supabase
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,10 @@
         "typescript": "^5"
       },
       "optionalDependencies": {
+        "@tailwindcss/oxide-darwin-arm64": "*",
+        "@tailwindcss/oxide-darwin-x64": "*",
+        "@tailwindcss/oxide-linux-arm64-gnu": "*",
+        "@tailwindcss/oxide-linux-x64-gnu": "*",
         "lightningcss-darwin-arm64": "*",
         "lightningcss-darwin-x64": "*",
         "lightningcss-linux-arm64-gnu": "*",
@@ -745,7 +749,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5172,6 +5175,54 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
+      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
+      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
+      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@token-burner/agent-cli": {
       "resolved": "packages/agent-cli",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,12 @@
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "*",
+        "lightningcss-darwin-x64": "*",
+        "lightningcss-linux-arm64-gnu": "*",
+        "lightningcss-linux-x64-gnu": "*"
       }
     },
     "apps/site/node_modules/@alloc/quick-lru": {
@@ -2967,7 +2973,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5931,6 +5936,66 @@
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/loupe": {


### PR DESCRIPTION
## Summary
- pins lightningcss + @tailwindcss/oxide platform binaries as optional deps so npm workspaces installs them on linux (fixes vercel build)
- records the real prod alias (token-burner-seven.vercel.app) and the monorepo-aware vercel project settings (root=apps/site, framework=nextjs, installCommand=cd ../.. && npm install) in INFRASTRUCTURE.md
- updates .env.example to the real prod url

## Test plan
- [x] vercel prod deploy succeeded (dpl_D8xegBW5neT2KH8Hh9oarGGc8LYJ)
- [x] https://token-burner-seven.vercel.app returns 200
- [ ] reviewer spot-checks the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)