### PR TITLE
fix: emit hex owner tokens to match the shared contract

### DIFF
--- a/apps/site/src/lib/server/onboarding.ts
+++ b/apps/site/src/lib/server/onboarding.ts
@@ -66,7 +66,7 @@ export const generateClaimCodeValue = (): string =>
   randomFromAlphabet(claimCodeLength, claimCodeAlphabet);
 
 export const generateOwnerTokenValue = (): string =>
-  `tb_owner_${randomBytes(ownerTokenBytes).toString("base64url")}`;
+  `tb_owner_${randomBytes(ownerTokenBytes).toString("hex")}`;
 
 export type CreatedClaimCode = {
   code: string;

--- a/tests/integration/onboarding.test.ts
+++ b/tests/integration/onboarding.test.ts
@@ -169,7 +169,9 @@ describe("registerHumanFromClaim", () => {
 
     expect(result.handle).toBe("alembic");
     expect(result.avatar).toBe("🔥");
-    expect(result.ownerToken).toMatch(/^tb_owner_[A-Za-z0-9_-]+$/);
+
+    const { parseRegisterResponse } = await import("@token-burner/shared");
+    expect(() => parseRegisterResponse(result)).not.toThrow();
 
     const [human] = await database
       .select()


### PR DESCRIPTION
## Summary
smoke test of chunk 2 showed /api/agent/register returning 500 with empty bodies. root cause: base64url randomness can include hyphens, but the shared ownerToken schema regex is `/^tb_owner_[A-Za-z0-9_]+$/` — no hyphen. ~75% of registrations crashed parsing their own success payload. switched to hex; test now runs the shared parser over the result so the class of bug can't return.

## Test plan
- [x] vitest run (7/7)
- [ ] redeploy + end-to-end smoke: mint → register → link returns 201