### PR TITLE
feat(chunk-3): cli register + link + whoami end-to-end

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "cd ../.. && npm run build --workspace @token-burner/shared",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "pretypecheck": "cd ../.. && npm run build --workspace @token-burner/shared",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6887,6 +6887,9 @@
     "packages/agent-cli": {
       "name": "@token-burner/agent-cli",
       "version": "0.1.0",
+      "dependencies": {
+        "@token-burner/shared": "file:../shared"
+      },
       "bin": {
         "token-burner-agent": "dist/cli.js"
       }

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -13,7 +13,12 @@
     "dist"
   ],
   "scripts": {
+    "prebuild": "cd ../.. && npm run build --workspace @token-burner/shared",
     "build": "tsc -p tsconfig.json",
+    "pretypecheck": "cd ../.. && npm run build --workspace @token-burner/shared",
     "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@token-burner/shared": "file:../shared"
   }
 }

--- a/packages/agent-cli/src/api/client.ts
+++ b/packages/agent-cli/src/api/client.ts
@@ -1,0 +1,82 @@
+import {
+  parseLinkResponse,
+  parseRegisterResponse,
+  type LinkRequest,
+  type LinkResponse,
+  type RegisterRequest,
+  type RegisterResponse,
+} from "@token-burner/shared";
+
+export type FetchLike = typeof fetch;
+
+export type ApiClientOptions = {
+  baseUrl: string;
+  fetchImpl?: FetchLike;
+};
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+const jsonHeaders = {
+  "Content-Type": "application/json",
+  Accept: "application/json",
+} as const;
+
+const postJson = async <TResponse>(
+  path: string,
+  body: unknown,
+  parse: (input: unknown) => TResponse,
+  { baseUrl, fetchImpl = fetch }: ApiClientOptions,
+): Promise<TResponse> => {
+  const url = `${trimTrailingSlash(baseUrl)}${path}`;
+  const response = await fetchImpl(url, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(body),
+  });
+
+  const raw = await response.text();
+  const parsed: unknown = raw.length > 0 ? safeJsonParse(raw) : null;
+
+  if (!response.ok) {
+    const message =
+      parsed && typeof parsed === "object" && parsed !== null && "error" in parsed
+        ? String((parsed as { error: unknown }).error)
+        : `request to ${path} failed (${response.status})`;
+    throw new ApiError(message, response.status, parsed);
+  }
+
+  return parse(parsed);
+};
+
+const trimTrailingSlash = (url: string): string =>
+  url.endsWith("/") ? url.slice(0, -1) : url;
+
+const safeJsonParse = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
+
+export const registerAgent = (
+  body: RegisterRequest,
+  options: ApiClientOptions,
+): Promise<RegisterResponse> =>
+  postJson("/api/agent/register", body, parseRegisterResponse, options);
+
+export const linkAgent = (
+  body: LinkRequest,
+  options: ApiClientOptions,
+): Promise<LinkResponse> =>
+  postJson("/api/agent/link", body, parseLinkResponse, options);

--- a/packages/agent-cli/src/args.ts
+++ b/packages/agent-cli/src/args.ts
@@ -1,0 +1,55 @@
+export type ParsedArgs = {
+  flags: Record<string, string>;
+  positional: string[];
+};
+
+export class CliArgsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliArgsError";
+  }
+}
+
+export const parseArgs = (argv: string[]): ParsedArgs => {
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token.startsWith("--")) {
+      const body = token.slice(2);
+      const eqIndex = body.indexOf("=");
+      if (eqIndex >= 0) {
+        const key = body.slice(0, eqIndex);
+        const value = body.slice(eqIndex + 1);
+        if (!key) {
+          throw new CliArgsError(`invalid flag: ${token}`);
+        }
+        flags[key] = value;
+        continue;
+      }
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith("--")) {
+        flags[body] = "true";
+        continue;
+      }
+      flags[body] = next;
+      index += 1;
+    } else {
+      positional.push(token);
+    }
+  }
+
+  return { flags, positional };
+};
+
+export const requireFlag = (
+  flags: Record<string, string>,
+  name: string,
+): string => {
+  const value = flags[name];
+  if (!value) {
+    throw new CliArgsError(`missing required flag: --${name}`);
+  }
+  return value;
+};

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -2,6 +2,10 @@
 
 import { pathToFileURL } from "node:url";
 
+import { runLinkCommand } from "./commands/link.js";
+import { runRegisterCommand } from "./commands/register.js";
+import { runWhoamiCommand } from "./commands/whoami.js";
+
 type CommandDefinition = {
   description: string;
   run: (args: string[]) => Promise<number> | number;
@@ -20,11 +24,11 @@ const createPendingCommand =
 export const commandDefinitions: Record<string, CommandDefinition> = {
   register: {
     description: "claim a code and register this installation",
-    run: createPendingCommand("register"),
+    run: (args) => runRegisterCommand({ args }),
   },
   link: {
     description: "link this installation to an existing human identity",
-    run: createPendingCommand("link"),
+    run: (args) => runLinkCommand({ args }),
   },
   burn: {
     description: "start a ceremonial token burn from the CLI",
@@ -32,7 +36,7 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
   },
   whoami: {
     description: "inspect the locally linked identity context",
-    run: createPendingCommand("whoami"),
+    run: () => runWhoamiCommand(),
   },
 };
 

--- a/packages/agent-cli/src/commands/link.ts
+++ b/packages/agent-cli/src/commands/link.ts
@@ -1,0 +1,82 @@
+import { CliArgsError, parseArgs, requireFlag } from "../args.js";
+import { ApiError, linkAgent, type FetchLike } from "../api/client.js";
+import {
+  loadLocalConfig,
+  saveLocalConfig,
+  type LocalConfig,
+} from "../config/local-store.js";
+import { defaultBaseUrl } from "../config/defaults.js";
+import type { CommandIo } from "./register.js";
+
+export type LinkCommandOptions = {
+  args: string[];
+  io?: Partial<CommandIo>;
+  fetchImpl?: FetchLike;
+  homeDir?: string;
+};
+
+export const runLinkCommand = async ({
+  args,
+  io,
+  fetchImpl,
+  homeDir,
+}: LinkCommandOptions): Promise<number> => {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+
+  let agentLabel: string;
+  let baseUrlOverride: string | undefined;
+  let ownerTokenOverride: string | undefined;
+  try {
+    const { flags } = parseArgs(args);
+    agentLabel = requireFlag(flags, "agent-label");
+    baseUrlOverride = flags["base-url"];
+    ownerTokenOverride = flags["owner-token"];
+  } catch (error) {
+    if (error instanceof CliArgsError) {
+      stderr.write(`${error.message}\n`);
+      stderr.write(
+        "usage: token-burner-agent link --agent-label LABEL [--owner-token TOKEN] [--base-url URL]\n",
+      );
+      return 2;
+    }
+    throw error;
+  }
+
+  const existing = await loadLocalConfig({ homeDir });
+  const ownerToken = ownerTokenOverride ?? existing?.ownerToken;
+  if (!ownerToken) {
+    stderr.write(
+      "no local owner token found. run `register` first, or pass --owner-token.\n",
+    );
+    return 1;
+  }
+
+  const baseUrl = baseUrlOverride ?? existing?.baseUrl ?? defaultBaseUrl;
+
+  try {
+    const response = await linkAgent(
+      { ownerToken, agentLabel },
+      { baseUrl, fetchImpl },
+    );
+
+    const nextConfig: LocalConfig = {
+      humanId: response.humanId,
+      agentInstallationId: response.agentInstallationId,
+      ownerToken,
+      baseUrl,
+    };
+    await saveLocalConfig(nextConfig, { homeDir });
+
+    stdout.write(
+      `linked installation ${response.agentInstallationId} to ${response.handle} ${response.avatar}\n`,
+    );
+    return 0;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      stderr.write(`link failed: ${error.message} (HTTP ${error.status})\n`);
+      return 1;
+    }
+    throw error;
+  }
+};

--- a/packages/agent-cli/src/commands/register.ts
+++ b/packages/agent-cli/src/commands/register.ts
@@ -1,0 +1,80 @@
+import { CliArgsError, parseArgs, requireFlag } from "../args.js";
+import { ApiError, registerAgent, type FetchLike } from "../api/client.js";
+import {
+  saveLocalConfig,
+  type LocalConfig,
+} from "../config/local-store.js";
+import { defaultBaseUrl } from "../config/defaults.js";
+
+export type CommandIo = {
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+};
+
+export type RegisterCommandOptions = {
+  args: string[];
+  io?: Partial<CommandIo>;
+  fetchImpl?: FetchLike;
+  homeDir?: string;
+};
+
+export const runRegisterCommand = async ({
+  args,
+  io,
+  fetchImpl,
+  homeDir,
+}: RegisterCommandOptions): Promise<number> => {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+
+  let claimCode: string;
+  let publicHandle: string;
+  let avatar: string;
+  let agentLabel: string;
+  let baseUrl: string;
+  try {
+    const { flags } = parseArgs(args);
+    claimCode = requireFlag(flags, "claim-code");
+    publicHandle = requireFlag(flags, "handle");
+    avatar = requireFlag(flags, "avatar");
+    agentLabel = requireFlag(flags, "agent-label");
+    baseUrl = flags["base-url"] ?? defaultBaseUrl;
+  } catch (error) {
+    if (error instanceof CliArgsError) {
+      stderr.write(`${error.message}\n`);
+      stderr.write(
+        "usage: token-burner-agent register --claim-code CODE --handle NAME --avatar X --agent-label LABEL [--base-url URL]\n",
+      );
+      return 2;
+    }
+    throw error;
+  }
+
+  try {
+    const response = await registerAgent(
+      { claimCode, publicHandle, avatar, agentLabel },
+      { baseUrl, fetchImpl },
+    );
+
+    const config: LocalConfig = {
+      humanId: response.humanId,
+      agentInstallationId: response.agentInstallationId,
+      ownerToken: response.ownerToken,
+      baseUrl,
+    };
+    await saveLocalConfig(config, { homeDir });
+
+    stdout.write(
+      `registered as ${response.handle} ${response.avatar} (${response.humanId})\n`,
+    );
+    stdout.write(`installation: ${response.agentInstallationId}\n`);
+    stdout.write(`owner token saved locally. keep it — it links future installs.\n`);
+    return 0;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      stderr.write(`register failed: ${error.message} (HTTP ${error.status})\n`);
+      return 1;
+    }
+    throw error;
+  }
+};

--- a/packages/agent-cli/src/commands/whoami.ts
+++ b/packages/agent-cli/src/commands/whoami.ts
@@ -1,0 +1,34 @@
+import { loadLocalConfig } from "../config/local-store.js";
+import type { CommandIo } from "./register.js";
+
+export type WhoamiCommandOptions = {
+  io?: Partial<CommandIo>;
+  homeDir?: string;
+};
+
+const redactOwnerToken = (ownerToken: string): string => {
+  if (ownerToken.length <= 16) {
+    return "tb_owner_…";
+  }
+  return `${ownerToken.slice(0, 12)}…${ownerToken.slice(-4)}`;
+};
+
+export const runWhoamiCommand = async ({
+  io,
+  homeDir,
+}: WhoamiCommandOptions = {}): Promise<number> => {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+
+  const config = await loadLocalConfig({ homeDir });
+  if (!config) {
+    stderr.write("no local token-burner config. run `register` first.\n");
+    return 1;
+  }
+
+  stdout.write(`humanId:         ${config.humanId}\n`);
+  stdout.write(`installationId:  ${config.agentInstallationId}\n`);
+  stdout.write(`ownerToken:      ${redactOwnerToken(config.ownerToken)}\n`);
+  stdout.write(`baseUrl:         ${config.baseUrl}\n`);
+  return 0;
+};

--- a/packages/agent-cli/src/config/defaults.ts
+++ b/packages/agent-cli/src/config/defaults.ts
@@ -1,0 +1,2 @@
+export const defaultBaseUrl =
+  process.env.TOKEN_BURNER_BASE_URL ?? "https://token-burner-seven.vercel.app";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,9 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -5,7 +5,7 @@ import {
   presetIdSchema,
   providerSchema,
   terminalBurnStatusSchema,
-} from "./domain";
+} from "./domain.js";
 
 const nonEmptyStringSchema = z.string().trim().min(1);
 const isoDatetimeSchema = z.string().datetime({ offset: true });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./api";
-export * from "./domain";
+export * from "./api.js";
+export * from "./domain.js";

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "dist",
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"]

--- a/tests/unit/agent-cli-commands.test.ts
+++ b/tests/unit/agent-cli-commands.test.ts
@@ -1,0 +1,279 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runLinkCommand } from "../../packages/agent-cli/src/commands/link";
+import { runRegisterCommand } from "../../packages/agent-cli/src/commands/register";
+import { runWhoamiCommand } from "../../packages/agent-cli/src/commands/whoami";
+import { saveLocalConfig } from "../../packages/agent-cli/src/config/local-store";
+
+type CapturedStreams = {
+  stdout: string;
+  stderr: string;
+};
+
+const captureStreams = () => {
+  const stdoutStream = new PassThrough();
+  const stderrStream = new PassThrough();
+  const out: string[] = [];
+  const err: string[] = [];
+  stdoutStream.on("data", (chunk) => out.push(chunk.toString()));
+  stderrStream.on("data", (chunk) => err.push(chunk.toString()));
+  return {
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    collected: (): CapturedStreams => ({
+      stdout: out.join(""),
+      stderr: err.join(""),
+    }),
+  };
+};
+
+const buildRegisterResponse = () => ({
+  humanId: "00000000-0000-0000-0000-000000000001",
+  agentInstallationId: "00000000-0000-0000-0000-000000000002",
+  ownerToken: "tb_owner_abcdef0123456789",
+  handle: "alembic",
+  avatar: "X",
+});
+
+const buildLinkResponse = () => ({
+  humanId: "00000000-0000-0000-0000-000000000001",
+  agentInstallationId: "00000000-0000-0000-0000-000000000099",
+  handle: "alembic",
+  avatar: "X",
+});
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("agent cli register command", () => {
+  let homeDir = "";
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(path.join(os.tmpdir(), "token-burner-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { force: true, recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it("calls the register endpoint and saves the owner token locally", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(201, buildRegisterResponse()));
+    const streams = captureStreams();
+
+    const exitCode = await runRegisterCommand({
+      args: [
+        "--claim-code",
+        "ABCD1234",
+        "--handle",
+        "alembic",
+        "--avatar",
+        "X",
+        "--agent-label",
+        "claude-code@laptop",
+        "--base-url",
+        "https://token-burner.test",
+      ],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      homeDir,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://token-burner.test/api/agent/register");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      claimCode: "ABCD1234",
+      publicHandle: "alembic",
+      avatar: "X",
+      agentLabel: "claude-code@laptop",
+    });
+
+    const stored = JSON.parse(
+      await readFile(
+        path.join(homeDir, ".config", "token-burner", "config.json"),
+        "utf8",
+      ),
+    );
+    expect(stored).toEqual({
+      humanId: "00000000-0000-0000-0000-000000000001",
+      agentInstallationId: "00000000-0000-0000-0000-000000000002",
+      ownerToken: "tb_owner_abcdef0123456789",
+      baseUrl: "https://token-burner.test",
+    });
+
+    expect(streams.collected().stdout).toContain("registered as alembic");
+  });
+
+  it("returns an argument error when a required flag is missing", async () => {
+    const streams = captureStreams();
+
+    const exitCode = await runRegisterCommand({
+      args: ["--claim-code", "ABCD1234"],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+    });
+
+    expect(exitCode).toBe(2);
+    expect(streams.collected().stderr).toContain("missing required flag");
+  });
+
+  it("surfaces API errors with the server message", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        jsonResponse(409, { error: "claim code is invalid, expired, or already claimed" }),
+      );
+    const streams = captureStreams();
+
+    const exitCode = await runRegisterCommand({
+      args: [
+        "--claim-code",
+        "EXPIRED0",
+        "--handle",
+        "x",
+        "--avatar",
+        "x",
+        "--agent-label",
+        "x",
+        "--base-url",
+        "https://token-burner.test",
+      ],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      homeDir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(streams.collected().stderr).toContain("claim code is invalid");
+  });
+});
+
+describe("agent cli link command", () => {
+  let homeDir = "";
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(path.join(os.tmpdir(), "token-burner-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { force: true, recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  it("links a new installation using the stored owner token", async () => {
+    await saveLocalConfig(
+      {
+        humanId: "00000000-0000-0000-0000-000000000001",
+        agentInstallationId: "00000000-0000-0000-0000-000000000002",
+        ownerToken: "tb_owner_deadbeef",
+        baseUrl: "https://token-burner.test",
+      },
+      { homeDir },
+    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(201, buildLinkResponse()));
+    const streams = captureStreams();
+
+    const exitCode = await runLinkCommand({
+      args: ["--agent-label", "codex@desktop"],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      homeDir,
+    });
+
+    expect(exitCode).toBe(0);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://token-burner.test/api/agent/link");
+    expect(JSON.parse(init.body as string)).toEqual({
+      ownerToken: "tb_owner_deadbeef",
+      agentLabel: "codex@desktop",
+    });
+
+    const stored = JSON.parse(
+      await readFile(
+        path.join(homeDir, ".config", "token-burner", "config.json"),
+        "utf8",
+      ),
+    );
+    expect(stored.agentInstallationId).toBe(
+      "00000000-0000-0000-0000-000000000099",
+    );
+    expect(stored.ownerToken).toBe("tb_owner_deadbeef");
+  });
+
+  it("refuses to link without an owner token", async () => {
+    const streams = captureStreams();
+
+    const exitCode = await runLinkCommand({
+      args: ["--agent-label", "x"],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(streams.collected().stderr).toContain("no local owner token");
+  });
+});
+
+describe("agent cli whoami command", () => {
+  let homeDir = "";
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(path.join(os.tmpdir(), "token-burner-cli-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { force: true, recursive: true });
+  });
+
+  it("prints the persisted identity with a redacted owner token", async () => {
+    await saveLocalConfig(
+      {
+        humanId: "human-123",
+        agentInstallationId: "install-456",
+        ownerToken: "tb_owner_deadbeefcafebabe1234",
+        baseUrl: "https://token-burner.test",
+      },
+      { homeDir },
+    );
+    const streams = captureStreams();
+
+    const exitCode = await runWhoamiCommand({
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+    });
+
+    expect(exitCode).toBe(0);
+    const out = streams.collected().stdout;
+    expect(out).toContain("human-123");
+    expect(out).toContain("install-456");
+    expect(out).toContain("tb_owner_dea");
+    expect(out).not.toContain("tb_owner_deadbeefcafebabe1234");
+  });
+
+  it("exits non-zero when no local config exists", async () => {
+    const streams = captureStreams();
+
+    const exitCode = await runWhoamiCommand({
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(streams.collected().stderr).toContain("no local token-burner config");
+  });
+});


### PR DESCRIPTION
## Summary
- real register/link/whoami commands (replacing the "not implemented" stubs)
- typed api client over the /api/agent/* endpoints using shared zod parsers
- shared package now builds to dist/ and exports main/types there so node runtime (CLI) can consume it; apps/site and agent-cli both got prebuild hooks that build shared first
- lightweight hand-rolled arg parser keeps the cli dep-free
- 7 new unit tests covering happy path, missing flags, api errors, missing owner token, and whoami with/without stored config

Closes chunk 3 of the delivery plan. `npx @token-burner/agent-cli register --claim-code ...` now actually claims + persists an owner token locally. Smoke-tested against prod:
- `register` against https://token-burner-seven.vercel.app returned the expected human/installation/ownerToken
- `whoami` read it back with a redacted token
- `link --agent-label second` created a second installation on the same human

## Test plan
- [x] vitest run (36/36 green)
- [x] npm run typecheck clean (includes pretypecheck build of shared)
- [x] apps/site next build clean (prebuild chain works)
- [x] agent-cli tsc build clean
- [x] local end-to-end: register → whoami → link against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)