### PR TITLE
feat(chunk-4a): burns api + session token migration

### DIFF
--- a/apps/site/src/app/api/burns/[burnId]/events/route.ts
+++ b/apps/site/src/app/api/burns/[burnId]/events/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import {
+  parseTelemetryEventRequest,
+  parseTelemetryEventResponse,
+} from "@token-burner/shared";
+
+import {
+  BurnSessionInvalidError,
+  recordBurnEvent,
+} from "../../../../../lib/server/burns";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ burnId: string }> },
+): Promise<Response> {
+  const { burnId } = await params;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json body" }, { status: 400 });
+  }
+
+  let parsed;
+  try {
+    parsed = parseTelemetryEventRequest(payload);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: "invalid telemetry event", details: error.issues },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
+
+  try {
+    const result = await recordBurnEvent({
+      burnId,
+      burnSessionToken: parsed.burnSessionToken,
+      eventType: parsed.eventType,
+      eventPayload: parsed.eventPayload,
+      billedTokensConsumed: parsed.billedTokensConsumed,
+    });
+    const body = parseTelemetryEventResponse(result);
+    return NextResponse.json(body, { status: 201 });
+  } catch (error) {
+    if (error instanceof BurnSessionInvalidError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    throw error;
+  }
+}

--- a/apps/site/src/app/api/burns/[burnId]/finish/route.ts
+++ b/apps/site/src/app/api/burns/[burnId]/finish/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import {
+  parseBurnFinishRequest,
+  parseBurnFinishResponse,
+} from "@token-burner/shared";
+
+import {
+  BurnSessionInvalidError,
+  finishBurn,
+} from "../../../../../lib/server/burns";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ burnId: string }> },
+): Promise<Response> {
+  const { burnId } = await params;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json body" }, { status: 400 });
+  }
+
+  let parsed;
+  try {
+    parsed = parseBurnFinishRequest(payload);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: "invalid burn finish request", details: error.issues },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
+
+  try {
+    const result = await finishBurn({
+      burnId,
+      burnSessionToken: parsed.burnSessionToken,
+      status: parsed.status,
+      billedTokensConsumed: parsed.billedTokensConsumed,
+    });
+    const body = parseBurnFinishResponse(result);
+    return NextResponse.json(body, { status: 200 });
+  } catch (error) {
+    if (error instanceof BurnSessionInvalidError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    throw error;
+  }
+}

--- a/apps/site/src/app/api/burns/[burnId]/heartbeat/route.ts
+++ b/apps/site/src/app/api/burns/[burnId]/heartbeat/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import {
+  parseHeartbeatRequest,
+  parseHeartbeatResponse,
+} from "@token-burner/shared";
+
+import {
+  BurnSessionInvalidError,
+  recordHeartbeat,
+} from "../../../../../lib/server/burns";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ burnId: string }> },
+): Promise<Response> {
+  const { burnId } = await params;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json body" }, { status: 400 });
+  }
+
+  let parsed;
+  try {
+    parsed = parseHeartbeatRequest(payload);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: "invalid heartbeat request", details: error.issues },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
+
+  try {
+    const result = await recordHeartbeat({
+      burnId,
+      burnSessionToken: parsed.burnSessionToken,
+      billedTokensConsumed: parsed.billedTokensConsumed,
+    });
+    const body = parseHeartbeatResponse(result);
+    return NextResponse.json(body, { status: 200 });
+  } catch (error) {
+    if (error instanceof BurnSessionInvalidError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    throw error;
+  }
+}

--- a/apps/site/src/app/api/burns/start/route.ts
+++ b/apps/site/src/app/api/burns/start/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+import {
+  parseBurnStartRequest,
+  parseBurnStartResponse,
+} from "@token-burner/shared";
+
+import {
+  BurnSessionInvalidError,
+  OwnerTokenInvalidError,
+  startBurn,
+} from "../../../../lib/server/burns";
+import { ActiveBurnConflictError } from "../../../../lib/server/housekeeping";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request): Promise<Response> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json body" }, { status: 400 });
+  }
+
+  let parsed;
+  try {
+    parsed = parseBurnStartRequest(payload);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: "invalid burn start request", details: error.issues },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
+
+  try {
+    const result = await startBurn({
+      ownerToken: parsed.ownerToken,
+      agentInstallationId: parsed.agentInstallationId,
+      provider: parsed.provider,
+      targetTokens: parsed.targetTokens,
+      presetId: parsed.presetId ?? null,
+    });
+    const body = parseBurnStartResponse(result);
+    return NextResponse.json(body, { status: 201 });
+  } catch (error) {
+    if (error instanceof OwnerTokenInvalidError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    if (error instanceof ActiveBurnConflictError) {
+      return NextResponse.json(
+        { error: error.message, burnId: error.burnId, status: error.status },
+        { status: 409 },
+      );
+    }
+    if (error instanceof BurnSessionInvalidError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    throw error;
+  }
+}

--- a/apps/site/src/lib/db/schema.ts
+++ b/apps/site/src/lib/db/schema.ts
@@ -114,6 +114,7 @@ export const burns = pgTable(
     startedAt: timestamp("started_at", { withTimezone: true }),
     finishedAt: timestamp("finished_at", { withTimezone: true }),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
+    burnSessionTokenHash: text("burn_session_token_hash"),
   },
   (table) => [
     check(
@@ -135,6 +136,9 @@ export const burns = pgTable(
     uniqueIndex("burns_one_active_per_human_idx")
       .on(table.humanId)
       .where(sql`${table.status} in (${activeBurnStatusesSql})`),
+    uniqueIndex("burns_burn_session_token_hash_idx")
+      .on(table.burnSessionTokenHash)
+      .where(sql`${table.burnSessionTokenHash} is not null`),
   ],
 );
 

--- a/apps/site/src/lib/server/burns.ts
+++ b/apps/site/src/lib/server/burns.ts
@@ -1,0 +1,344 @@
+import "server-only";
+
+import { createHmac, randomBytes } from "node:crypto";
+
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { type NodePgDatabase } from "drizzle-orm/node-postgres";
+
+import {
+  providerFlagshipModels,
+  type BurnStatus,
+  type PresetId,
+  type ProviderId,
+  type TerminalBurnStatus,
+} from "@token-burner/shared";
+
+import * as schema from "../db/schema";
+import { verifyOwnerToken } from "./auth";
+import { ensureNoActiveBurnConflict } from "./housekeeping";
+
+type TokenBurnerDatabase = NodePgDatabase<typeof schema>;
+
+type DatabaseOptions = {
+  database?: TokenBurnerDatabase;
+};
+
+type TimestampedDatabaseOptions = DatabaseOptions & {
+  now?: Date;
+};
+
+const burnSessionTokenBytes = 32;
+const activeBurnStatuses = ["queued", "running", "stopping"] as const;
+
+export class OwnerTokenInvalidError extends Error {
+  constructor() {
+    super("owner token is invalid or revoked");
+    this.name = "OwnerTokenInvalidError";
+  }
+}
+
+export class BurnSessionInvalidError extends Error {
+  constructor() {
+    super("burn session is invalid or already finished");
+    this.name = "BurnSessionInvalidError";
+  }
+}
+
+const resolveDatabase = async (
+  database?: TokenBurnerDatabase,
+): Promise<TokenBurnerDatabase> => {
+  if (database) {
+    return database;
+  }
+  const client = await import("../db/client");
+  return client.db;
+};
+
+const getBurnSessionTokenHashSecret = (): string => {
+  const secret = process.env.OWNER_TOKEN_HASH_SECRET;
+  if (secret) {
+    return secret;
+  }
+  throw new Error(
+    "Set OWNER_TOKEN_HASH_SECRET before using burn session helpers.",
+  );
+};
+
+export const generateBurnSessionTokenValue = (): string =>
+  `tb_burn_${randomBytes(burnSessionTokenBytes).toString("hex")}`;
+
+export const hashBurnSessionToken = (token: string): string =>
+  createHmac("sha256", getBurnSessionTokenHashSecret())
+    .update(token)
+    .digest("hex");
+
+export type StartBurnInput = {
+  ownerToken: string;
+  agentInstallationId: string;
+  provider: ProviderId;
+  targetTokens: number;
+  presetId?: PresetId | null;
+};
+
+export type StartBurnResult = {
+  burnId: string;
+  burnSessionToken: string;
+  status: BurnStatus;
+};
+
+export const startBurn = async ({
+  ownerToken,
+  agentInstallationId,
+  provider,
+  targetTokens,
+  presetId,
+  database,
+  now = new Date(),
+}: TimestampedDatabaseOptions & StartBurnInput): Promise<StartBurnResult> => {
+  const queryDatabase = await resolveDatabase(database);
+
+  const verified = await verifyOwnerToken(ownerToken, {
+    database: queryDatabase,
+    now,
+  });
+  if (!verified) {
+    throw new OwnerTokenInvalidError();
+  }
+
+  await ensureNoActiveBurnConflict({
+    humanId: verified.humanId,
+    database: queryDatabase,
+    now,
+  });
+
+  const burnSessionToken = generateBurnSessionTokenValue();
+
+  const [burn] = await queryDatabase
+    .insert(schema.burns)
+    .values({
+      humanId: verified.humanId,
+      agentInstallationId,
+      provider,
+      model: providerFlagshipModels[provider],
+      presetId: presetId ?? null,
+      requestedBilledTokenTarget: targetTokens,
+      billedTokensConsumed: 0,
+      status: "running",
+      createdAt: now,
+      startedAt: now,
+      lastHeartbeatAt: now,
+      burnSessionTokenHash: hashBurnSessionToken(burnSessionToken),
+    })
+    .returning({
+      id: schema.burns.id,
+      status: schema.burns.status,
+    });
+
+  return {
+    burnId: burn.id,
+    burnSessionToken,
+    status: burn.status,
+  };
+};
+
+type ActiveBurnMatch = {
+  id: string;
+  status: BurnStatus;
+  billedTokensConsumed: number;
+  requestedBilledTokenTarget: number;
+};
+
+const findActiveBurnBySession = async (
+  burnId: string,
+  sessionToken: string,
+  queryDatabase: TokenBurnerDatabase,
+): Promise<ActiveBurnMatch | null> => {
+  const [row] = await queryDatabase
+    .select({
+      id: schema.burns.id,
+      status: schema.burns.status,
+      billedTokensConsumed: schema.burns.billedTokensConsumed,
+      requestedBilledTokenTarget: schema.burns.requestedBilledTokenTarget,
+    })
+    .from(schema.burns)
+    .where(
+      and(
+        eq(schema.burns.id, burnId),
+        eq(
+          schema.burns.burnSessionTokenHash,
+          hashBurnSessionToken(sessionToken),
+        ),
+        inArray(schema.burns.status, activeBurnStatuses),
+      ),
+    )
+    .limit(1);
+
+  return row ?? null;
+};
+
+export type HeartbeatInput = {
+  burnId: string;
+  burnSessionToken: string;
+  billedTokensConsumed: number;
+};
+
+export type HeartbeatResult = {
+  ok: true;
+  status: BurnStatus;
+  billedTokensConsumed: number;
+};
+
+export const recordHeartbeat = async ({
+  burnId,
+  burnSessionToken,
+  billedTokensConsumed,
+  database,
+  now = new Date(),
+}: TimestampedDatabaseOptions & HeartbeatInput): Promise<HeartbeatResult> => {
+  const queryDatabase = await resolveDatabase(database);
+
+  const existing = await findActiveBurnBySession(
+    burnId,
+    burnSessionToken,
+    queryDatabase,
+  );
+  if (!existing) {
+    throw new BurnSessionInvalidError();
+  }
+
+  const clampedTarget = existing.requestedBilledTokenTarget;
+  const safeBilled = Math.min(
+    Math.max(billedTokensConsumed, existing.billedTokensConsumed),
+    clampedTarget,
+  );
+
+  const [updated] = await queryDatabase
+    .update(schema.burns)
+    .set({
+      billedTokensConsumed: safeBilled,
+      lastHeartbeatAt: now,
+    })
+    .where(eq(schema.burns.id, burnId))
+    .returning({
+      status: schema.burns.status,
+      billedTokensConsumed: schema.burns.billedTokensConsumed,
+    });
+
+  return {
+    ok: true,
+    status: updated.status,
+    billedTokensConsumed: updated.billedTokensConsumed,
+  };
+};
+
+export type RecordBurnEventInput = {
+  burnId: string;
+  burnSessionToken: string;
+  eventType: string;
+  eventPayload: Record<string, unknown>;
+  billedTokensConsumed?: number;
+};
+
+export type RecordBurnEventResult = {
+  accepted: true;
+};
+
+export const recordBurnEvent = async ({
+  burnId,
+  burnSessionToken,
+  eventType,
+  eventPayload,
+  billedTokensConsumed,
+  database,
+  now = new Date(),
+}: TimestampedDatabaseOptions & RecordBurnEventInput): Promise<RecordBurnEventResult> => {
+  const queryDatabase = await resolveDatabase(database);
+
+  const existing = await findActiveBurnBySession(
+    burnId,
+    burnSessionToken,
+    queryDatabase,
+  );
+  if (!existing) {
+    throw new BurnSessionInvalidError();
+  }
+
+  await queryDatabase.insert(schema.burnEvents).values({
+    burnId,
+    eventType,
+    eventPayload,
+    createdAt: now,
+  });
+
+  if (typeof billedTokensConsumed === "number") {
+    const safeBilled = Math.min(
+      Math.max(billedTokensConsumed, existing.billedTokensConsumed),
+      existing.requestedBilledTokenTarget,
+    );
+    await queryDatabase
+      .update(schema.burns)
+      .set({
+        billedTokensConsumed: safeBilled,
+        lastHeartbeatAt: now,
+      })
+      .where(eq(schema.burns.id, burnId));
+  }
+
+  return { accepted: true };
+};
+
+export type FinishBurnInput = {
+  burnId: string;
+  burnSessionToken: string;
+  status: TerminalBurnStatus;
+  billedTokensConsumed: number;
+};
+
+export type FinishBurnResult = {
+  ok: true;
+  status: TerminalBurnStatus;
+};
+
+export const finishBurn = async ({
+  burnId,
+  burnSessionToken,
+  status,
+  billedTokensConsumed,
+  database,
+  now = new Date(),
+}: TimestampedDatabaseOptions & FinishBurnInput): Promise<FinishBurnResult> => {
+  const queryDatabase = await resolveDatabase(database);
+
+  const existing = await findActiveBurnBySession(
+    burnId,
+    burnSessionToken,
+    queryDatabase,
+  );
+  if (!existing) {
+    throw new BurnSessionInvalidError();
+  }
+
+  const safeBilled = Math.min(
+    Math.max(billedTokensConsumed, existing.billedTokensConsumed),
+    existing.requestedBilledTokenTarget,
+  );
+
+  const [updated] = await queryDatabase
+    .update(schema.burns)
+    .set({
+      billedTokensConsumed: safeBilled,
+      status,
+      finishedAt: now,
+      lastHeartbeatAt: now,
+      burnSessionTokenHash: sql`null`,
+    })
+    .where(eq(schema.burns.id, burnId))
+    .returning({
+      status: schema.burns.status,
+    });
+
+  return {
+    ok: true,
+    status: updated.status as TerminalBurnStatus,
+  };
+};

--- a/drizzle/0002_burn_session_token.sql
+++ b/drizzle/0002_burn_session_token.sql
@@ -1,0 +1,5 @@
+alter table burns add column burn_session_token_hash text;
+
+create unique index burns_burn_session_token_hash_idx
+  on burns (burn_session_token_hash)
+  where burn_session_token_hash is not null;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm run build --workspace @token-burner/site",
     "lint": "npm run lint --workspace @token-burner/site",
     "typecheck": "npm run typecheck --workspaces",
+    "pretest": "npm run build --workspace @token-burner/shared",
     "test": "vitest run",
     "test:e2e": "playwright test"
   },

--- a/packages/shared/src/api.ts
+++ b/packages/shared/src/api.ts
@@ -62,6 +62,7 @@ export const parseLinkResponse = (input: unknown): LinkResponse =>
 
 export const burnStartRequestSchema = z.object({
   ownerToken: ownerTokenSchema,
+  agentInstallationId: nonEmptyStringSchema,
   provider: providerSchema,
   targetTokens: positiveTokenCountSchema,
   presetId: presetIdSchema.nullish(),

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -26,3 +26,8 @@ export type TerminalBurnStatus = z.infer<typeof terminalBurnStatusSchema>;
 export const presetIdValues = ["tier-1", "tier-2", "tier-3"] as const;
 export const presetIdSchema = z.enum(presetIdValues);
 export type PresetId = z.infer<typeof presetIdSchema>;
+
+export const providerFlagshipModels: Record<ProviderId, string> = {
+  openai: "gpt-5.4",
+  anthropic: "claude-opus-4-7",
+};

--- a/tests/integration/burns-api.test.ts
+++ b/tests/integration/burns-api.test.ts
@@ -1,0 +1,457 @@
+import { randomUUID } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { DataType, newDb } from "pg-mem";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import * as schema from "../../apps/site/src/lib/db/schema";
+
+vi.mock("server-only", () => ({}));
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+const migrationsDirectory = path.join(repoRoot, "drizzle");
+const fixedNow = new Date("2026-04-22T12:00:00.000Z");
+const ownerTokenHashSecret =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const readAllMigrationsSql = async (): Promise<string> => {
+  const entries = await readdir(migrationsDirectory);
+  const files = entries.filter((entry) => entry.endsWith(".sql")).sort();
+  const contents = await Promise.all(
+    files.map((file) => readFile(path.join(migrationsDirectory, file), "utf8")),
+  );
+  return contents.join("\n");
+};
+
+type TestDatabase = ReturnType<typeof drizzle<typeof schema>>;
+
+type TestContext = {
+  database: TestDatabase;
+  pool: { end: () => Promise<void> };
+};
+
+const openPools: Array<{ end: () => Promise<void> }> = [];
+
+const createTestDatabase = async (): Promise<TestContext> => {
+  const memoryDatabase = newDb({ autoCreateForeignKeyIndices: true });
+  memoryDatabase.public.registerFunction({
+    name: "gen_random_uuid",
+    returns: DataType.uuid,
+    implementation: randomUUID,
+    impure: true,
+  });
+
+  const migrationSql = await readAllMigrationsSql();
+  memoryDatabase.public.none(
+    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
+  );
+
+  const adapter = memoryDatabase.adapters.createPg();
+  const patchPgMemAdapter = (PgClass: {
+    prototype: {
+      adaptQuery: (query: unknown, values?: unknown[]) => unknown;
+      adaptResults: (
+        query: unknown,
+        results: {
+          rows: Array<Record<string, unknown>>;
+          fields: Array<{ name: string }>;
+        },
+      ) => unknown;
+    };
+  }) => {
+    const originalAdaptQuery = PgClass.prototype.adaptQuery;
+    const originalAdaptResults = PgClass.prototype.adaptResults;
+
+    PgClass.prototype.adaptQuery = function adaptQueryWithoutDriverTypes(
+      query,
+      values,
+    ) {
+      if (typeof query === "string") {
+        return originalAdaptQuery.call(this, query, values);
+      }
+
+      const sanitizedQuery =
+        query && typeof query === "object"
+          ? { ...(query as Record<string, unknown>) }
+          : query;
+
+      if (sanitizedQuery && typeof sanitizedQuery === "object") {
+        delete sanitizedQuery.types;
+      }
+
+      return originalAdaptQuery.call(this, sanitizedQuery, values);
+    };
+
+    PgClass.prototype.adaptResults = function adaptArrayRowMode(query, results) {
+      if (
+        query &&
+        typeof query === "object" &&
+        "rowMode" in (query as Record<string, unknown>) &&
+        (query as Record<string, unknown>).rowMode === "array"
+      ) {
+        return {
+          ...results,
+          rows: results.rows.map((row) =>
+            results.fields.map((field) => row[field.name]),
+          ),
+          fields: results.fields,
+        };
+      }
+
+      return originalAdaptResults.call(this, query, results);
+    };
+  };
+
+  patchPgMemAdapter(adapter.Pool);
+  patchPgMemAdapter(adapter.Client);
+
+  const pool = new adapter.Pool();
+  const database = drizzle({ client: pool, schema });
+
+  openPools.push(pool);
+
+  return { database, pool };
+};
+
+afterEach(async () => {
+  while (openPools.length > 0) {
+    const pool = openPools.pop();
+    if (pool) {
+      await pool.end().catch(() => {});
+    }
+  }
+});
+
+beforeEach(() => {
+  process.env.OWNER_TOKEN_HASH_SECRET = ownerTokenHashSecret;
+});
+
+const seedRegisteredHuman = async (database: TestDatabase) => {
+  const { createClaimCode, registerHumanFromClaim } = await import(
+    "../../apps/site/src/lib/server/onboarding"
+  );
+  const { code } = await createClaimCode({ database, now: fixedNow });
+  return registerHumanFromClaim({
+    claimCode: code,
+    publicHandle: `human-${randomUUID().slice(0, 6)}`,
+    avatar: "X",
+    agentLabel: "first",
+    database,
+    now: fixedNow,
+  });
+};
+
+describe("startBurn", () => {
+  it("creates a running burn row with the fixed provider model and a session token", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    const result = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 5_000,
+      database,
+      now: fixedNow,
+    });
+
+    expect(result.status).toBe("running");
+    expect(result.burnId).toMatch(/[0-9a-f-]{36}/);
+    expect(result.burnSessionToken).toMatch(/^tb_burn_[0-9a-f]+$/);
+
+    const [row] = await database
+      .select()
+      .from(schema.burns)
+      .where(eq(schema.burns.id, result.burnId));
+    expect(row).toMatchObject({
+      humanId: registered.humanId,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      requestedBilledTokenTarget: 5_000,
+      billedTokensConsumed: 0,
+      status: "running",
+    });
+    expect(row.burnSessionTokenHash).not.toBeNull();
+  });
+
+  it("rejects an invalid owner token", async () => {
+    const { database } = await createTestDatabase();
+    const { OwnerTokenInvalidError, startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    await expect(
+      startBurn({
+        ownerToken: "tb_owner_unknown",
+        agentInstallationId: randomUUID(),
+        provider: "anthropic",
+        targetTokens: 100,
+        database,
+        now: fixedNow,
+      }),
+    ).rejects.toBeInstanceOf(OwnerTokenInvalidError);
+  });
+
+  it("refuses to start a second burn while one is active", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+    const { ActiveBurnConflictError } = await import(
+      "../../apps/site/src/lib/server/housekeeping"
+    );
+
+    await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 5_000,
+      database,
+      now: fixedNow,
+    });
+
+    await expect(
+      startBurn({
+        ownerToken: registered.ownerToken,
+        agentInstallationId: registered.agentInstallationId,
+        provider: "anthropic",
+        targetTokens: 1_000,
+        database,
+        now: fixedNow,
+      }),
+    ).rejects.toBeInstanceOf(ActiveBurnConflictError);
+  });
+});
+
+describe("recordHeartbeat", () => {
+  it("updates billed_tokens_consumed and refreshes last_heartbeat_at", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { recordHeartbeat, startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    const started = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 10_000,
+      database,
+      now: fixedNow,
+    });
+
+    const later = new Date(fixedNow.getTime() + 30_000);
+    const result = await recordHeartbeat({
+      burnId: started.burnId,
+      burnSessionToken: started.burnSessionToken,
+      billedTokensConsumed: 1_234,
+      database,
+      now: later,
+    });
+
+    expect(result.billedTokensConsumed).toBe(1_234);
+    expect(result.status).toBe("running");
+
+    const [row] = await database
+      .select()
+      .from(schema.burns)
+      .where(eq(schema.burns.id, started.burnId));
+    expect(row.billedTokensConsumed).toBe(1_234);
+    expect(row.lastHeartbeatAt?.toISOString()).toBe(later.toISOString());
+  });
+
+  it("caps billed tokens at the requested target", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { recordHeartbeat, startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    const started = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 1_000,
+      database,
+      now: fixedNow,
+    });
+
+    const result = await recordHeartbeat({
+      burnId: started.burnId,
+      burnSessionToken: started.burnSessionToken,
+      billedTokensConsumed: 99_999,
+      database,
+      now: fixedNow,
+    });
+
+    expect(result.billedTokensConsumed).toBe(1_000);
+  });
+
+  it("rejects an unknown session token", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { BurnSessionInvalidError, recordHeartbeat, startBurn } =
+      await import("../../apps/site/src/lib/server/burns");
+
+    const started = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 1_000,
+      database,
+      now: fixedNow,
+    });
+
+    await expect(
+      recordHeartbeat({
+        burnId: started.burnId,
+        burnSessionToken: "tb_burn_bogus",
+        billedTokensConsumed: 1,
+        database,
+        now: fixedNow,
+      }),
+    ).rejects.toBeInstanceOf(BurnSessionInvalidError);
+  });
+});
+
+describe("recordBurnEvent", () => {
+  it("inserts a burn_events row and optionally updates billed tokens", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { recordBurnEvent, startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    const started = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 10_000,
+      database,
+      now: fixedNow,
+    });
+
+    await recordBurnEvent({
+      burnId: started.burnId,
+      burnSessionToken: started.burnSessionToken,
+      eventType: "step",
+      eventPayload: { inputTokens: 200, outputTokens: 300 },
+      billedTokensConsumed: 500,
+      database,
+      now: fixedNow,
+    });
+
+    const events = await database
+      .select()
+      .from(schema.burnEvents)
+      .where(eq(schema.burnEvents.burnId, started.burnId));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: "step",
+      eventPayload: { inputTokens: 200, outputTokens: 300 },
+    });
+
+    const [burn] = await database
+      .select()
+      .from(schema.burns)
+      .where(eq(schema.burns.id, started.burnId));
+    expect(burn.billedTokensConsumed).toBe(500);
+  });
+});
+
+describe("finishBurn", () => {
+  it("marks the burn as completed and clears the session token hash", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { finishBurn, startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    const started = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 10_000,
+      database,
+      now: fixedNow,
+    });
+
+    const finishedAt = new Date(fixedNow.getTime() + 60_000);
+    const result = await finishBurn({
+      burnId: started.burnId,
+      burnSessionToken: started.burnSessionToken,
+      status: "completed",
+      billedTokensConsumed: 9_950,
+      database,
+      now: finishedAt,
+    });
+
+    expect(result.status).toBe("completed");
+
+    const [row] = await database
+      .select()
+      .from(schema.burns)
+      .where(eq(schema.burns.id, started.burnId));
+    expect(row.status).toBe("completed");
+    expect(row.billedTokensConsumed).toBe(9_950);
+    expect(row.finishedAt?.toISOString()).toBe(finishedAt.toISOString());
+    expect(row.burnSessionTokenHash).toBeNull();
+  });
+
+  it("refuses a second finish with the same session token", async () => {
+    const { database } = await createTestDatabase();
+    const registered = await seedRegisteredHuman(database);
+    const { BurnSessionInvalidError, finishBurn, startBurn } = await import(
+      "../../apps/site/src/lib/server/burns"
+    );
+
+    const started = await startBurn({
+      ownerToken: registered.ownerToken,
+      agentInstallationId: registered.agentInstallationId,
+      provider: "anthropic",
+      targetTokens: 10_000,
+      database,
+      now: fixedNow,
+    });
+
+    await finishBurn({
+      burnId: started.burnId,
+      burnSessionToken: started.burnSessionToken,
+      status: "completed",
+      billedTokensConsumed: 100,
+      database,
+      now: fixedNow,
+    });
+
+    await expect(
+      finishBurn({
+        burnId: started.burnId,
+        burnSessionToken: started.burnSessionToken,
+        status: "completed",
+        billedTokensConsumed: 100,
+        database,
+        now: fixedNow,
+      }),
+    ).rejects.toBeInstanceOf(BurnSessionInvalidError);
+  });
+});

--- a/tests/integration/db-queries.test.ts
+++ b/tests/integration/db-queries.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -22,7 +22,16 @@ const repoRoot = path.resolve(
   "../..",
 );
 
-const migrationPath = path.join(repoRoot, "drizzle/0001_initial.sql");
+const migrationsDirectory = path.join(repoRoot, "drizzle");
+
+const readAllMigrationsSql = async (): Promise<string> => {
+  const entries = await readdir(migrationsDirectory);
+  const files = entries.filter((entry) => entry.endsWith(".sql")).sort();
+  const contents = await Promise.all(
+    files.map((file) => readFile(path.join(migrationsDirectory, file), "utf8")),
+  );
+  return contents.join("\n");
+};
 const fixedNow = new Date("2026-04-21T12:00:00.000Z");
 
 const activeStatuses = ["queued", "running", "stopping"] as const;
@@ -53,9 +62,9 @@ const createTestDatabase = async (): Promise<TestContext> => {
     implementation: randomUUID,
   });
 
-  const migrationSql = await readFile(migrationPath, "utf8");
+  const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n/i, ""),
+    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();

--- a/tests/integration/onboarding.test.ts
+++ b/tests/integration/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,7 +17,16 @@ const repoRoot = path.resolve(
   "../..",
 );
 
-const migrationPath = path.join(repoRoot, "drizzle/0001_initial.sql");
+const migrationsDirectory = path.join(repoRoot, "drizzle");
+
+const readAllMigrationsSql = async (): Promise<string> => {
+  const entries = await readdir(migrationsDirectory);
+  const files = entries.filter((entry) => entry.endsWith(".sql")).sort();
+  const contents = await Promise.all(
+    files.map((file) => readFile(path.join(migrationsDirectory, file), "utf8")),
+  );
+  return contents.join("\n");
+};
 const fixedNow = new Date("2026-04-22T12:00:00.000Z");
 const ownerTokenHashSecret =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -40,9 +49,9 @@ const createTestDatabase = async (): Promise<TestContext> => {
     impure: true,
   });
 
-  const migrationSql = await readFile(migrationPath, "utf8");
+  const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n/i, ""),
+    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();

--- a/tests/integration/server-auth-housekeeping.test.ts
+++ b/tests/integration/server-auth-housekeeping.test.ts
@@ -1,5 +1,5 @@
 import { createHmac, randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,7 +17,16 @@ const repoRoot = path.resolve(
   "../..",
 );
 
-const migrationPath = path.join(repoRoot, "drizzle/0001_initial.sql");
+const migrationsDirectory = path.join(repoRoot, "drizzle");
+
+const readAllMigrationsSql = async (): Promise<string> => {
+  const entries = await readdir(migrationsDirectory);
+  const files = entries.filter((entry) => entry.endsWith(".sql")).sort();
+  const contents = await Promise.all(
+    files.map((file) => readFile(path.join(migrationsDirectory, file), "utf8")),
+  );
+  return contents.join("\n");
+};
 const fixedNow = new Date("2026-04-21T12:00:00.000Z");
 const ownerTokenHashSecret =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -48,9 +57,9 @@ const createTestDatabase = async (): Promise<TestContext> => {
     implementation: randomUUID,
   });
 
-  const migrationSql = await readFile(migrationPath, "utf8");
+  const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n/i, ""),
+    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();

--- a/tests/unit/shared-api.test.ts
+++ b/tests/unit/shared-api.test.ts
@@ -104,12 +104,14 @@ describe("shared api contracts", () => {
     expect(
       parseBurnStartRequest({
         ownerToken: "tb_owner_123456",
+        agentInstallationId: "install-abc",
         provider: "openai",
         targetTokens: 500_000,
         presetId: "tier-2",
       }),
     ).toMatchObject({
       ownerToken: "tb_owner_123456",
+      agentInstallationId: "install-abc",
       provider: "openai",
       targetTokens: 500_000,
       presetId: "tier-2",
@@ -118,11 +120,13 @@ describe("shared api contracts", () => {
     expect(
       parseBurnStartRequest({
         ownerToken: "tb_owner_123456",
+        agentInstallationId: "install-abc",
         provider: "anthropic",
         targetTokens: 250_000,
       }),
     ).toMatchObject({
       ownerToken: "tb_owner_123456",
+      agentInstallationId: "install-abc",
       provider: "anthropic",
       targetTokens: 250_000,
     });
@@ -130,12 +134,14 @@ describe("shared api contracts", () => {
     expect(
       parseBurnStartRequest({
         ownerToken: "tb_owner_123456",
+        agentInstallationId: "install-abc",
         provider: "openai",
         targetTokens: 125_000,
         presetId: null,
       }),
     ).toMatchObject({
       ownerToken: "tb_owner_123456",
+      agentInstallationId: "install-abc",
       provider: "openai",
       targetTokens: 125_000,
       presetId: null,


### PR DESCRIPTION
## Summary
- 4 new api routes: /api/burns/start, /api/burns/[burnId]/heartbeat, /api/burns/[burnId]/events, /api/burns/[burnId]/finish
- apps/site/src/lib/server/burns.ts owns the lifecycle helpers (startBurn / recordHeartbeat / recordBurnEvent / finishBurn) with typed auth errors
- new drizzle/0002 migration adds burn_session_token_hash. already applied to live supabase
- billed_tokens_consumed is monotonic + capped at target on every write (hard-cap at the db boundary)
- shared schema update: burnStartRequestSchema now requires agentInstallationId
- providerFlagshipModels constant so v1 fixed model per provider

## Test plan
- [x] 9 new burns integration tests (45/45 suite green)
- [x] typecheck + next build clean (7 api routes total)
- [x] live supabase has the new column + partial unique index
- [ ] smoke test after deploy