### PR TITLE
feat(chunk-4b): cli burn command + anthropic adapter + runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1691,20 +1691,6 @@
         "node": ">= 0.4"
       }
     },
-    "apps/site/node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "apps/site/node_modules/es-shim-unscopables": {
       "version": "1.1.0",
       "dev": true,
@@ -2371,20 +2357,6 @@
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/site/node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4377,6 +4349,36 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -5265,10 +5267,19 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/pg": {
@@ -5398,6 +5409,30 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -5407,6 +5442,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -5441,7 +5482,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5495,6 +5535,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -5546,6 +5598,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/discontinuous-range": {
@@ -5684,7 +5745,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5699,7 +5759,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5709,7 +5768,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5726,10 +5784,24 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5787,6 +5859,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5815,6 +5896,41 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5834,7 +5950,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5851,7 +5966,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5876,7 +5990,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5890,7 +6003,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5916,8 +6028,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5929,13 +6055,21 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/immutable": {
@@ -6083,10 +6217,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/moment": {
@@ -6110,7 +6264,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6152,6 +6305,46 @@
       "funding": {
         "type": "individual",
         "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-hash": {
@@ -6650,6 +6843,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6668,7 +6867,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -6842,6 +7040,31 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -6888,6 +7111,7 @@
       "name": "@token-burner/agent-cli",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.40.0",
         "@token-burner/shared": "file:../shared"
       },
       "bin": {

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.0",
     "@token-burner/shared": "file:../shared"
   }
 }

--- a/packages/agent-cli/src/api/client.ts
+++ b/packages/agent-cli/src/api/client.ts
@@ -1,10 +1,22 @@
 import {
+  parseBurnFinishResponse,
+  parseBurnStartResponse,
+  parseHeartbeatResponse,
   parseLinkResponse,
   parseRegisterResponse,
+  parseTelemetryEventResponse,
+  type BurnFinishRequest,
+  type BurnFinishResponse,
+  type BurnStartRequest,
+  type BurnStartResponse,
+  type HeartbeatRequest,
+  type HeartbeatResponse,
   type LinkRequest,
   type LinkResponse,
   type RegisterRequest,
   type RegisterResponse,
+  type TelemetryEventRequest,
+  type TelemetryEventResponse,
 } from "@token-burner/shared";
 
 export type FetchLike = typeof fetch;
@@ -80,3 +92,45 @@ export const linkAgent = (
   options: ApiClientOptions,
 ): Promise<LinkResponse> =>
   postJson("/api/agent/link", body, parseLinkResponse, options);
+
+export const startBurn = (
+  body: BurnStartRequest,
+  options: ApiClientOptions,
+): Promise<BurnStartResponse> =>
+  postJson("/api/burns/start", body, parseBurnStartResponse, options);
+
+export const postHeartbeat = (
+  burnId: string,
+  body: HeartbeatRequest,
+  options: ApiClientOptions,
+): Promise<HeartbeatResponse> =>
+  postJson(
+    `/api/burns/${encodeURIComponent(burnId)}/heartbeat`,
+    body,
+    parseHeartbeatResponse,
+    options,
+  );
+
+export const postBurnEvent = (
+  burnId: string,
+  body: TelemetryEventRequest,
+  options: ApiClientOptions,
+): Promise<TelemetryEventResponse> =>
+  postJson(
+    `/api/burns/${encodeURIComponent(burnId)}/events`,
+    body,
+    parseTelemetryEventResponse,
+    options,
+  );
+
+export const finishBurn = (
+  burnId: string,
+  body: BurnFinishRequest,
+  options: ApiClientOptions,
+): Promise<BurnFinishResponse> =>
+  postJson(
+    `/api/burns/${encodeURIComponent(burnId)}/finish`,
+    body,
+    parseBurnFinishResponse,
+    options,
+  );

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { pathToFileURL } from "node:url";
 
+import { runBurnCommand } from "./commands/burn.js";
 import { runLinkCommand } from "./commands/link.js";
 import { runRegisterCommand } from "./commands/register.js";
 import { runWhoamiCommand } from "./commands/whoami.js";
@@ -32,7 +33,7 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
   },
   burn: {
     description: "start a ceremonial token burn from the CLI",
-    run: createPendingCommand("burn"),
+    run: (args) => runBurnCommand({ args }),
   },
   whoami: {
     description: "inspect the locally linked identity context",

--- a/packages/agent-cli/src/commands/burn.ts
+++ b/packages/agent-cli/src/commands/burn.ts
@@ -1,0 +1,137 @@
+import { providerSchema, type ProviderId } from "@token-burner/shared";
+
+import { CliArgsError, parseArgs, requireFlag } from "../args.js";
+import { ApiError, type FetchLike } from "../api/client.js";
+import { loadLocalConfig } from "../config/local-store.js";
+import { defaultBaseUrl } from "../config/defaults.js";
+import { createAnthropicAdapter } from "../providers/anthropic.js";
+import { resolveProviderCredentials } from "../providers/resolve-credentials.js";
+import {
+  ProviderCredentialsMissingError,
+  type ProviderAdapter,
+  type ProviderCredentials,
+} from "../providers/types.js";
+import { runBurn, type RunBurnResult } from "../runtime/run-burn.js";
+import type { CommandIo } from "./register.js";
+
+export type BurnCommandOptions = {
+  args: string[];
+  io?: Partial<CommandIo>;
+  fetchImpl?: FetchLike;
+  homeDir?: string;
+  adapterFactory?: (credentials: ProviderCredentials) => ProviderAdapter;
+  credentialsResolver?: typeof resolveProviderCredentials;
+  disableParentWatch?: boolean;
+};
+
+const defaultAdapterFactory = (
+  credentials: ProviderCredentials,
+): ProviderAdapter => {
+  if (credentials.providerId === "anthropic") {
+    return createAnthropicAdapter(credentials);
+  }
+  throw new Error(
+    `provider ${credentials.providerId} is not supported in this build. anthropic only for now.`,
+  );
+};
+
+const parseProvider = (value: string): ProviderId => providerSchema.parse(value);
+
+const parsePositiveInt = (value: string, label: string): number => {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new CliArgsError(`--${label} must be a positive integer`);
+  }
+  return parsed;
+};
+
+export const runBurnCommand = async ({
+  args,
+  io,
+  fetchImpl,
+  homeDir,
+  adapterFactory = defaultAdapterFactory,
+  credentialsResolver = resolveProviderCredentials,
+  disableParentWatch,
+}: BurnCommandOptions): Promise<number> => {
+  const stdout = io?.stdout ?? process.stdout;
+  const stderr = io?.stderr ?? process.stderr;
+
+  let provider: ProviderId;
+  let targetTokens: number;
+  let presetId: string | null;
+  let baseUrlOverride: string | undefined;
+  try {
+    const { flags } = parseArgs(args);
+    provider = parseProvider(requireFlag(flags, "provider"));
+    targetTokens = parsePositiveInt(requireFlag(flags, "target"), "target");
+    presetId = flags.preset ?? null;
+    baseUrlOverride = flags["base-url"];
+  } catch (error) {
+    if (error instanceof CliArgsError) {
+      stderr.write(`${error.message}\n`);
+      stderr.write(
+        "usage: token-burner-agent burn --provider anthropic --target N [--preset tier-1|tier-2|tier-3] [--base-url URL]\n",
+      );
+      return 2;
+    }
+    throw error;
+  }
+
+  const config = await loadLocalConfig({ homeDir });
+  if (!config) {
+    stderr.write(
+      "no local token-burner config. run `register` or `link` first.\n",
+    );
+    return 1;
+  }
+
+  const baseUrl = baseUrlOverride ?? config.baseUrl ?? defaultBaseUrl;
+
+  let adapter: ProviderAdapter;
+  try {
+    const credentials = credentialsResolver(provider);
+    adapter = adapterFactory(credentials);
+  } catch (error) {
+    if (error instanceof ProviderCredentialsMissingError) {
+      stderr.write(`${error.message}\n`);
+      return 1;
+    }
+    throw error;
+  }
+
+  stdout.write(
+    `starting burn: provider=${provider} model=${adapter.model} target=${targetTokens}\n`,
+  );
+
+  let result: RunBurnResult;
+  try {
+    result = await runBurn({
+      ownerToken: config.ownerToken,
+      agentInstallationId: config.agentInstallationId,
+      provider,
+      targetTokens,
+      presetId,
+      adapter,
+      apiOptions: { baseUrl, fetchImpl },
+      onProgress: (snapshot) => {
+        stdout.write(
+          `  step ${snapshot.stepIndex}: +${snapshot.stepInputTokens}in/${snapshot.stepOutputTokens}out → ${snapshot.totalBilledTokens}/${snapshot.targetTokens}\n`,
+        );
+      },
+      parentWatch: disableParentWatch ? { enabled: false } : undefined,
+    });
+  } catch (error) {
+    if (error instanceof ApiError) {
+      stderr.write(`burn failed: ${error.message} (HTTP ${error.status})\n`);
+      return 1;
+    }
+    throw error;
+  }
+
+  stdout.write(
+    `burn ${result.terminalStatus}: ${result.totalBilledTokens} billed tokens over ${result.steps} step(s) (${result.stopReason})\n`,
+  );
+  stdout.write(`burn id: ${result.burnId}\n`);
+  return result.terminalStatus === "completed" ? 0 : 1;
+};

--- a/packages/agent-cli/src/providers/anthropic.ts
+++ b/packages/agent-cli/src/providers/anthropic.ts
@@ -1,0 +1,49 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+import { providerFlagshipModels } from "@token-burner/shared";
+
+import type {
+  BurnStepRequest,
+  BurnStepResult,
+  ProviderAdapter,
+  ProviderCredentials,
+} from "./types.js";
+
+const anthropicModel = providerFlagshipModels.anthropic;
+
+const burnPrompt =
+  "Produce a long stream of plausible-sounding lorem ipsum filler text. Do not ask questions or request clarification. Keep generating until you are told to stop.";
+
+export const createAnthropicAdapter = (
+  credentials: ProviderCredentials,
+): ProviderAdapter => {
+  if (credentials.providerId !== "anthropic") {
+    throw new Error(
+      `createAnthropicAdapter called with ${credentials.providerId} credentials`,
+    );
+  }
+
+  const client = new Anthropic({ apiKey: credentials.apiKey });
+
+  return {
+    providerId: "anthropic",
+    model: anthropicModel,
+    runBurnStep: async ({ maxOutputTokens }: BurnStepRequest): Promise<BurnStepResult> => {
+      const response = await client.messages.create({
+        model: anthropicModel,
+        max_tokens: maxOutputTokens,
+        messages: [{ role: "user", content: burnPrompt }],
+      });
+
+      const inputTokens = response.usage.input_tokens;
+      const outputTokens = response.usage.output_tokens;
+
+      return {
+        inputTokens,
+        outputTokens,
+        totalBilledTokens: inputTokens + outputTokens,
+        stopReason: response.stop_reason,
+      };
+    },
+  };
+};

--- a/packages/agent-cli/src/providers/resolve-credentials.ts
+++ b/packages/agent-cli/src/providers/resolve-credentials.ts
@@ -1,0 +1,27 @@
+import type { ProviderId } from "@token-burner/shared";
+
+import {
+  ProviderCredentialsMissingError,
+  type ProviderCredentials,
+} from "./types.js";
+
+export type EnvLike = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+const envKeysByProvider: Record<ProviderId, readonly string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+};
+
+export const resolveProviderCredentials = (
+  providerId: ProviderId,
+  env: EnvLike = process.env,
+): ProviderCredentials => {
+  const candidates = envKeysByProvider[providerId];
+  for (const key of candidates) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return { providerId, apiKey: value.trim() };
+    }
+  }
+  throw new ProviderCredentialsMissingError(providerId);
+};

--- a/packages/agent-cli/src/providers/types.ts
+++ b/packages/agent-cli/src/providers/types.ts
@@ -1,0 +1,32 @@
+import type { ProviderId } from "@token-burner/shared";
+
+export type BurnStepResult = {
+  inputTokens: number;
+  outputTokens: number;
+  totalBilledTokens: number;
+  stopReason: string | null;
+};
+
+export type BurnStepRequest = {
+  maxOutputTokens: number;
+};
+
+export type ProviderAdapter = {
+  providerId: ProviderId;
+  model: string;
+  runBurnStep: (request: BurnStepRequest) => Promise<BurnStepResult>;
+};
+
+export type ProviderCredentials = {
+  providerId: ProviderId;
+  apiKey: string;
+};
+
+export class ProviderCredentialsMissingError extends Error {
+  constructor(providerId: ProviderId) {
+    super(
+      `no local ${providerId} credentials found. token-burner only uses official provider credentials from your environment.`,
+    );
+    this.name = "ProviderCredentialsMissingError";
+  }
+}

--- a/packages/agent-cli/src/runtime/compute-safe-request.ts
+++ b/packages/agent-cli/src/runtime/compute-safe-request.ts
@@ -1,0 +1,26 @@
+const maxOutputTokensPerCall = 4_096;
+const inputOverheadEstimate = 64;
+const safetyMargin = 32;
+
+export type SafeRequestDecision =
+  | { kind: "request"; maxOutputTokens: number }
+  | { kind: "stop"; reason: string };
+
+export const computeSafeRequest = (
+  remainingBudget: number,
+): SafeRequestDecision => {
+  const usableBudget =
+    remainingBudget - inputOverheadEstimate - safetyMargin;
+
+  if (usableBudget <= 0) {
+    return { kind: "stop", reason: "remaining budget below input overhead" };
+  }
+
+  const maxOutputTokens = Math.min(usableBudget, maxOutputTokensPerCall);
+
+  if (maxOutputTokens < 64) {
+    return { kind: "stop", reason: "remaining budget below minimum step" };
+  }
+
+  return { kind: "request", maxOutputTokens };
+};

--- a/packages/agent-cli/src/runtime/parent-watch.ts
+++ b/packages/agent-cli/src/runtime/parent-watch.ts
@@ -1,0 +1,50 @@
+export type ParentWatchOptions = {
+  pollIntervalMs?: number;
+  getPpid?: () => number;
+};
+
+export type ParentWatchHandle = {
+  stop: () => void;
+  ensureAlive: () => boolean;
+};
+
+export const watchParent = (
+  onParentExit: () => void,
+  options: ParentWatchOptions = {},
+): ParentWatchHandle => {
+  const { pollIntervalMs = 2_000, getPpid = () => process.ppid } = options;
+  let stopped = false;
+  const startingPpid = getPpid();
+  let currentPpid = startingPpid;
+
+  const ensureAlive = (): boolean => {
+    if (stopped) {
+      return false;
+    }
+    currentPpid = getPpid();
+    if (startingPpid !== 1 && currentPpid === 1) {
+      return false;
+    }
+    return true;
+  };
+
+  const timer = setInterval(() => {
+    if (!ensureAlive()) {
+      clearInterval(timer);
+      stopped = true;
+      onParentExit();
+    }
+  }, pollIntervalMs);
+
+  if (typeof (timer as { unref?: () => unknown }).unref === "function") {
+    (timer as { unref: () => unknown }).unref();
+  }
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+    },
+    ensureAlive,
+  };
+};

--- a/packages/agent-cli/src/runtime/run-burn.ts
+++ b/packages/agent-cli/src/runtime/run-burn.ts
@@ -1,0 +1,213 @@
+import { presetIdSchema, type PresetId, type ProviderId, type TerminalBurnStatus } from "@token-burner/shared";
+
+import {
+  ApiError,
+  finishBurn as finishBurnApi,
+  postBurnEvent,
+  postHeartbeat,
+  startBurn as startBurnApi,
+  type ApiClientOptions,
+} from "../api/client.js";
+import type { ProviderAdapter } from "../providers/types.js";
+import { computeSafeRequest } from "./compute-safe-request.js";
+import { watchParent, type ParentWatchHandle } from "./parent-watch.js";
+
+export type RunBurnOptions = {
+  ownerToken: string;
+  agentInstallationId: string;
+  provider: ProviderId;
+  targetTokens: number;
+  presetId?: PresetId | string | null;
+  adapter: ProviderAdapter;
+  apiOptions: ApiClientOptions;
+  onProgress?: (snapshot: BurnProgressSnapshot) => void;
+  parentWatch?: {
+    enabled?: boolean;
+    pollIntervalMs?: number;
+  };
+};
+
+export type BurnProgressSnapshot = {
+  burnId: string;
+  stepIndex: number;
+  stepInputTokens: number;
+  stepOutputTokens: number;
+  totalBilledTokens: number;
+  targetTokens: number;
+};
+
+export type RunBurnResult = {
+  burnId: string;
+  terminalStatus: TerminalBurnStatus;
+  totalBilledTokens: number;
+  steps: number;
+  stopReason: string;
+};
+
+const clampBilled = (billed: number, target: number): number =>
+  Math.max(0, Math.min(billed, target));
+
+export const runBurn = async ({
+  ownerToken,
+  agentInstallationId,
+  provider,
+  targetTokens,
+  presetId = null,
+  adapter,
+  apiOptions,
+  onProgress,
+  parentWatch,
+}: RunBurnOptions): Promise<RunBurnResult> => {
+  const started = await startBurnApi(
+    {
+      ownerToken,
+      agentInstallationId,
+      provider,
+      targetTokens,
+      presetId: presetId ? presetIdSchema.parse(presetId) : undefined,
+    },
+    apiOptions,
+  );
+
+  const burnId = started.burnId;
+  const burnSessionToken = started.burnSessionToken;
+
+  let terminalStatus: TerminalBurnStatus = "failed";
+  let stopReason = "unknown";
+  let totalBilledTokens = 0;
+  let stepIndex = 0;
+  let parentHandle: ParentWatchHandle | null = null;
+  let parentExited = false;
+  const signalHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> =
+    [];
+
+  const installSignal = (signal: NodeJS.Signals) => {
+    const handler = () => {
+      parentExited = true;
+      stopReason = `received ${signal}`;
+    };
+    process.on(signal, handler);
+    signalHandlers.push({ signal, handler });
+  };
+
+  const uninstallSignals = () => {
+    for (const { signal, handler } of signalHandlers) {
+      process.off(signal, handler);
+    }
+  };
+
+  installSignal("SIGINT");
+  installSignal("SIGTERM");
+  installSignal("SIGHUP");
+
+  if (parentWatch?.enabled !== false) {
+    parentHandle = watchParent(
+      () => {
+        parentExited = true;
+        stopReason = "parent session ended";
+      },
+      { pollIntervalMs: parentWatch?.pollIntervalMs },
+    );
+  }
+
+  try {
+    while (true) {
+      if (parentExited) {
+        terminalStatus = "interrupted";
+        break;
+      }
+
+      const remaining = targetTokens - totalBilledTokens;
+      const decision = computeSafeRequest(remaining);
+      if (decision.kind === "stop") {
+        terminalStatus = "completed";
+        stopReason = decision.reason;
+        break;
+      }
+
+      let stepResult;
+      try {
+        stepResult = await adapter.runBurnStep({
+          maxOutputTokens: decision.maxOutputTokens,
+        });
+      } catch (error) {
+        terminalStatus = "failed";
+        stopReason =
+          error instanceof Error
+            ? `provider error: ${error.message}`
+            : "provider error";
+        break;
+      }
+
+      stepIndex += 1;
+      totalBilledTokens = clampBilled(
+        totalBilledTokens + stepResult.totalBilledTokens,
+        targetTokens,
+      );
+
+      onProgress?.({
+        burnId,
+        stepIndex,
+        stepInputTokens: stepResult.inputTokens,
+        stepOutputTokens: stepResult.outputTokens,
+        totalBilledTokens,
+        targetTokens,
+      });
+
+      await postHeartbeat(
+        burnId,
+        { burnSessionToken, billedTokensConsumed: totalBilledTokens },
+        apiOptions,
+      );
+
+      await postBurnEvent(
+        burnId,
+        {
+          burnSessionToken,
+          eventType: "step",
+          billedTokensConsumed: totalBilledTokens,
+          eventPayload: {
+            stepIndex,
+            inputTokens: stepResult.inputTokens,
+            outputTokens: stepResult.outputTokens,
+            stopReason: stepResult.stopReason,
+            model: adapter.model,
+          },
+        },
+        apiOptions,
+      );
+
+      if (totalBilledTokens >= targetTokens) {
+        terminalStatus = "completed";
+        stopReason = "reached target";
+        break;
+      }
+    }
+  } finally {
+    try {
+      await finishBurnApi(
+        burnId,
+        {
+          burnSessionToken,
+          status: terminalStatus,
+          billedTokensConsumed: totalBilledTokens,
+        },
+        apiOptions,
+      );
+    } catch (error) {
+      if (!(error instanceof ApiError)) {
+        throw error;
+      }
+    }
+    parentHandle?.stop();
+    uninstallSignals();
+  }
+
+  return {
+    burnId,
+    terminalStatus,
+    totalBilledTokens,
+    steps: stepIndex,
+    stopReason,
+  };
+};

--- a/tests/unit/agent-cli-burn.test.ts
+++ b/tests/unit/agent-cli-burn.test.ts
@@ -1,0 +1,238 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { computeSafeRequest } from "../../packages/agent-cli/src/runtime/compute-safe-request";
+import {
+  ProviderCredentialsMissingError,
+  type ProviderAdapter,
+  type ProviderCredentials,
+} from "../../packages/agent-cli/src/providers/types";
+import { resolveProviderCredentials } from "../../packages/agent-cli/src/providers/resolve-credentials";
+import { runBurnCommand } from "../../packages/agent-cli/src/commands/burn";
+import { saveLocalConfig } from "../../packages/agent-cli/src/config/local-store";
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const captureStreams = () => {
+  const stdoutStream = new PassThrough();
+  const stderrStream = new PassThrough();
+  const out: string[] = [];
+  const err: string[] = [];
+  stdoutStream.on("data", (chunk) => out.push(chunk.toString()));
+  stderrStream.on("data", (chunk) => err.push(chunk.toString()));
+  return {
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    collected: () => ({ stdout: out.join(""), stderr: err.join("") }),
+  };
+};
+
+const buildFakeAdapter = (perCall: { input: number; output: number }): ProviderAdapter => ({
+  providerId: "anthropic",
+  model: "claude-opus-4-7",
+  runBurnStep: async () => ({
+    inputTokens: perCall.input,
+    outputTokens: perCall.output,
+    totalBilledTokens: perCall.input + perCall.output,
+    stopReason: "end_turn",
+  }),
+});
+
+describe("computeSafeRequest", () => {
+  it("returns a request sized under the remaining budget", () => {
+    expect(computeSafeRequest(10_000)).toEqual({
+      kind: "request",
+      maxOutputTokens: expect.any(Number),
+    });
+    const decision = computeSafeRequest(10_000);
+    expect(decision.kind).toBe("request");
+    if (decision.kind === "request") {
+      expect(decision.maxOutputTokens).toBeLessThanOrEqual(10_000 - 64 - 32);
+    }
+  });
+
+  it("stops when the remaining budget is below the minimum step", () => {
+    const decision = computeSafeRequest(100);
+    expect(decision.kind).toBe("stop");
+  });
+
+  it("caps max tokens at 4096 even when budget is large", () => {
+    const decision = computeSafeRequest(100_000);
+    if (decision.kind !== "request") {
+      throw new Error("expected request decision");
+    }
+    expect(decision.maxOutputTokens).toBe(4_096);
+  });
+});
+
+describe("resolveProviderCredentials", () => {
+  it("reads ANTHROPIC_API_KEY from env", () => {
+    const result = resolveProviderCredentials("anthropic", {
+      ANTHROPIC_API_KEY: "sk-ant-test",
+    });
+    expect(result.apiKey).toBe("sk-ant-test");
+  });
+
+  it("throws ProviderCredentialsMissingError when key is absent", () => {
+    expect(() => resolveProviderCredentials("anthropic", {})).toThrow(
+      ProviderCredentialsMissingError,
+    );
+  });
+
+  it("ignores empty strings", () => {
+    expect(() =>
+      resolveProviderCredentials("openai", { OPENAI_API_KEY: "   " }),
+    ).toThrow(ProviderCredentialsMissingError);
+  });
+});
+
+describe("runBurnCommand", () => {
+  let homeDir = "";
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(path.join(os.tmpdir(), "token-burner-burn-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { force: true, recursive: true });
+    vi.restoreAllMocks();
+  });
+
+  const seedConfig = () =>
+    saveLocalConfig(
+      {
+        humanId: "00000000-0000-0000-0000-000000000001",
+        agentInstallationId: "00000000-0000-0000-0000-000000000002",
+        ownerToken: "tb_owner_deadbeef",
+        baseUrl: "https://token-burner.test",
+      },
+      { homeDir },
+    );
+
+  it("runs a full burn loop, posts heartbeats + events, and finishes completed", async () => {
+    await seedConfig();
+    const fetchCalls: Array<{ url: string; body: unknown }> = [];
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async (url, init) => {
+        const body = init?.body ? JSON.parse(init.body as string) : null;
+        fetchCalls.push({ url: url.toString(), body });
+        if (url.toString().endsWith("/api/burns/start")) {
+          return jsonResponse(201, {
+            burnId: "burn-1",
+            burnSessionToken: "tb_burn_deadbeef",
+            status: "running",
+          });
+        }
+        if (url.toString().includes("/heartbeat")) {
+          return jsonResponse(200, {
+            ok: true,
+            status: "running",
+            billedTokensConsumed: body.billedTokensConsumed,
+          });
+        }
+        if (url.toString().includes("/events")) {
+          return jsonResponse(201, { accepted: true });
+        }
+        if (url.toString().includes("/finish")) {
+          return jsonResponse(200, { ok: true, status: body.status });
+        }
+        throw new Error(`unexpected fetch to ${url}`);
+      });
+    const streams = captureStreams();
+
+    const exitCode = await runBurnCommand({
+      args: [
+        "--provider",
+        "anthropic",
+        "--target",
+        "500",
+        "--base-url",
+        "https://token-burner.test",
+      ],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      homeDir,
+      credentialsResolver: () => ({ providerId: "anthropic", apiKey: "sk-ant-test" }),
+      adapterFactory: () => buildFakeAdapter({ input: 50, output: 150 }),
+      disableParentWatch: true,
+    });
+
+    expect(exitCode).toBe(0);
+    const urls = fetchCalls.map((call) => call.url);
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        "https://token-burner.test/api/burns/start",
+        "https://token-burner.test/api/burns/burn-1/heartbeat",
+        "https://token-burner.test/api/burns/burn-1/events",
+        "https://token-burner.test/api/burns/burn-1/finish",
+      ]),
+    );
+
+    const finishCall = fetchCalls.find((call) => call.url.endsWith("/finish"));
+    expect(finishCall?.body).toMatchObject({ status: "completed" });
+    expect(streams.collected().stdout).toContain("burn completed");
+  });
+
+  it("exits with code 2 when a required flag is missing", async () => {
+    await seedConfig();
+    const streams = captureStreams();
+
+    const exitCode = await runBurnCommand({
+      args: ["--provider", "anthropic"],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+      disableParentWatch: true,
+    });
+
+    expect(exitCode).toBe(2);
+    expect(streams.collected().stderr).toContain("missing required flag");
+  });
+
+  it("refuses to burn when no local config exists", async () => {
+    const streams = captureStreams();
+
+    const exitCode = await runBurnCommand({
+      args: ["--provider", "anthropic", "--target", "100"],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+      credentialsResolver: () => ({ providerId: "anthropic", apiKey: "k" }),
+      adapterFactory: () => buildFakeAdapter({ input: 1, output: 1 }),
+      disableParentWatch: true,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(streams.collected().stderr).toContain(
+      "no local token-burner config",
+    );
+  });
+
+  it("reports missing provider credentials and exits", async () => {
+    await seedConfig();
+    const streams = captureStreams();
+
+    const exitCode = await runBurnCommand({
+      args: ["--provider", "anthropic", "--target", "100"],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+      credentialsResolver: () => {
+        throw new ProviderCredentialsMissingError("anthropic");
+      },
+      adapterFactory: () => {
+        throw new Error("should not be called");
+      },
+      disableParentWatch: true,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(streams.collected().stderr).toContain("no local anthropic credentials");
+  });
+});


### PR DESCRIPTION
## Summary
real end-to-end burn loop. verified against prod anthropic: target=600, 591 billed tokens consumed in 1 step, db row marked completed.

- provider adapter contract + anthropic impl (@anthropic-ai/sdk, fixed flagship model)
- env-first credential resolver (OPENAI_API_KEY / ANTHROPIC_API_KEY only — no keyring, no fs)
- compute-safe-request: max_tokens budget with input overhead + safety margin so we under-shoot rather than overshoot
- parent-watch: polls process.ppid and flips a flag when parent session ends
- run-burn: start → step+heartbeat+event loop → finish; signal handlers for SIGINT/SIGTERM/SIGHUP
- cli burn command wires args + config + credentials + adapter + run-burn

## Test plan
- [x] 10 new unit tests (55/55 suite green)
- [x] typecheck + cli build clean
- [x] live anthropic smoke: target=600 → 591 billed, status=completed, 1 burn_events row