### PR TITLE
feat(chunk-5): openai adapter + preset tiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6367,6 +6367,51 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -7112,7 +7157,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.0",
-        "@token-burner/shared": "file:../shared"
+        "@token-burner/shared": "file:../shared",
+        "openai": "^4.80.0"
       },
       "bin": {
         "token-burner-agent": "dist/cli.js"

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.0",
-    "@token-burner/shared": "file:../shared"
+    "@token-burner/shared": "file:../shared",
+    "openai": "^4.80.0"
   }
 }

--- a/packages/agent-cli/src/commands/burn.ts
+++ b/packages/agent-cli/src/commands/burn.ts
@@ -1,10 +1,17 @@
-import { providerSchema, type ProviderId } from "@token-burner/shared";
+import {
+  getBurnPreset,
+  presetIdSchema,
+  providerSchema,
+  type PresetId,
+  type ProviderId,
+} from "@token-burner/shared";
 
 import { CliArgsError, parseArgs, requireFlag } from "../args.js";
 import { ApiError, type FetchLike } from "../api/client.js";
 import { loadLocalConfig } from "../config/local-store.js";
 import { defaultBaseUrl } from "../config/defaults.js";
 import { createAnthropicAdapter } from "../providers/anthropic.js";
+import { createOpenAIAdapter } from "../providers/openai.js";
 import { resolveProviderCredentials } from "../providers/resolve-credentials.js";
 import {
   ProviderCredentialsMissingError,
@@ -30,8 +37,11 @@ const defaultAdapterFactory = (
   if (credentials.providerId === "anthropic") {
     return createAnthropicAdapter(credentials);
   }
+  if (credentials.providerId === "openai") {
+    return createOpenAIAdapter(credentials);
+  }
   throw new Error(
-    `provider ${credentials.providerId} is not supported in this build. anthropic only for now.`,
+    `provider ${credentials.providerId} is not wired in this build.`,
   );
 };
 
@@ -59,19 +69,35 @@ export const runBurnCommand = async ({
 
   let provider: ProviderId;
   let targetTokens: number;
-  let presetId: string | null;
+  let presetId: PresetId | null;
   let baseUrlOverride: string | undefined;
   try {
     const { flags } = parseArgs(args);
     provider = parseProvider(requireFlag(flags, "provider"));
-    targetTokens = parsePositiveInt(requireFlag(flags, "target"), "target");
-    presetId = flags.preset ?? null;
+    const presetFlag = flags.preset;
+    const targetFlag = flags.target;
+    if (presetFlag && targetFlag) {
+      throw new CliArgsError(
+        "pass --preset or --target, not both. the preset's target is authoritative.",
+      );
+    }
+    if (presetFlag) {
+      const parsedPresetId = presetIdSchema.parse(presetFlag);
+      presetId = parsedPresetId;
+      targetTokens = getBurnPreset(parsedPresetId).targetTokens;
+    } else {
+      presetId = null;
+      targetTokens = parsePositiveInt(
+        requireFlag(flags, "target"),
+        "target",
+      );
+    }
     baseUrlOverride = flags["base-url"];
   } catch (error) {
     if (error instanceof CliArgsError) {
       stderr.write(`${error.message}\n`);
       stderr.write(
-        "usage: token-burner-agent burn --provider anthropic --target N [--preset tier-1|tier-2|tier-3] [--base-url URL]\n",
+        "usage: token-burner-agent burn --provider anthropic (--target N | --preset tier-1|tier-2|tier-3) [--base-url URL]\n",
       );
       return 2;
     }

--- a/packages/agent-cli/src/providers/openai.ts
+++ b/packages/agent-cli/src/providers/openai.ts
@@ -1,0 +1,51 @@
+import OpenAI from "openai";
+
+import { providerFlagshipModels } from "@token-burner/shared";
+
+import type {
+  BurnStepRequest,
+  BurnStepResult,
+  ProviderAdapter,
+  ProviderCredentials,
+} from "./types.js";
+
+const openaiModel = providerFlagshipModels.openai;
+
+const burnPrompt =
+  "Produce a long stream of plausible-sounding lorem ipsum filler text. Do not ask questions or request clarification. Keep generating until you are told to stop.";
+
+export const createOpenAIAdapter = (
+  credentials: ProviderCredentials,
+): ProviderAdapter => {
+  if (credentials.providerId !== "openai") {
+    throw new Error(
+      `createOpenAIAdapter called with ${credentials.providerId} credentials`,
+    );
+  }
+
+  const client = new OpenAI({ apiKey: credentials.apiKey });
+
+  return {
+    providerId: "openai",
+    model: openaiModel,
+    runBurnStep: async ({ maxOutputTokens }: BurnStepRequest): Promise<BurnStepResult> => {
+      const response = await client.chat.completions.create({
+        model: openaiModel,
+        max_completion_tokens: maxOutputTokens,
+        messages: [{ role: "user", content: burnPrompt }],
+      });
+
+      const usage = response.usage;
+      const inputTokens = usage?.prompt_tokens ?? 0;
+      const outputTokens = usage?.completion_tokens ?? 0;
+      const stopReason = response.choices[0]?.finish_reason ?? null;
+
+      return {
+        inputTokens,
+        outputTokens,
+        totalBilledTokens: inputTokens + outputTokens,
+        stopReason,
+      };
+    },
+  };
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./api.js";
 export * from "./domain.js";
+export * from "./presets.js";

--- a/packages/shared/src/presets.ts
+++ b/packages/shared/src/presets.ts
@@ -1,0 +1,39 @@
+import type { PresetId } from "./domain.js";
+
+export type BurnPreset = {
+  id: PresetId;
+  label: string;
+  targetTokens: number;
+  blurb: string;
+};
+
+export const burnPresets: readonly BurnPreset[] = [
+  {
+    id: "tier-1",
+    label: "Amuse-Bouche",
+    targetTokens: 25_000,
+    blurb: "a modest gesture. just enough to show up on the board.",
+  },
+  {
+    id: "tier-2",
+    label: "Statement Piece",
+    targetTokens: 250_000,
+    blurb: "midweek indulgence. burning casually, in public.",
+  },
+  {
+    id: "tier-3",
+    label: "Couture Run",
+    targetTokens: 2_500_000,
+    blurb: "committed waste. the kind other burners will talk about.",
+  },
+] as const;
+
+const presetsById: Record<PresetId, BurnPreset> = burnPresets.reduce(
+  (map, preset) => {
+    map[preset.id] = preset;
+    return map;
+  },
+  {} as Record<PresetId, BurnPreset>,
+);
+
+export const getBurnPreset = (id: PresetId): BurnPreset => presetsById[id];

--- a/tests/unit/agent-cli-burn.test.ts
+++ b/tests/unit/agent-cli-burn.test.ts
@@ -235,4 +235,83 @@ describe("runBurnCommand", () => {
     expect(exitCode).toBe(1);
     expect(streams.collected().stderr).toContain("no local anthropic credentials");
   });
+
+  it("resolves --preset to the preset's targetTokens and forwards presetId to the api", async () => {
+    await seedConfig();
+    const fetchCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async (url, init) => {
+        const body = init?.body ? JSON.parse(init.body as string) : {};
+        fetchCalls.push({ url: url.toString(), body });
+        if (url.toString().endsWith("/api/burns/start")) {
+          return jsonResponse(201, {
+            burnId: "burn-preset",
+            burnSessionToken: "tb_burn_x",
+            status: "running",
+          });
+        }
+        if (url.toString().includes("/heartbeat")) {
+          return jsonResponse(200, {
+            ok: true,
+            status: "running",
+            billedTokensConsumed: body.billedTokensConsumed,
+          });
+        }
+        if (url.toString().includes("/events")) {
+          return jsonResponse(201, { accepted: true });
+        }
+        if (url.toString().includes("/finish")) {
+          return jsonResponse(200, { ok: true, status: body.status });
+        }
+        throw new Error(`unexpected fetch to ${url}`);
+      });
+    const streams = captureStreams();
+
+    const exitCode = await runBurnCommand({
+      args: [
+        "--provider",
+        "anthropic",
+        "--preset",
+        "tier-1",
+        "--base-url",
+        "https://token-burner.test",
+      ],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      homeDir,
+      credentialsResolver: () => ({ providerId: "anthropic", apiKey: "k" }),
+      adapterFactory: () => buildFakeAdapter({ input: 50, output: 4_000 }),
+      disableParentWatch: true,
+    });
+
+    expect(exitCode).toBe(0);
+    const startCall = fetchCalls.find((call) => call.url.endsWith("/api/burns/start"));
+    expect(startCall?.body).toMatchObject({
+      targetTokens: 25_000,
+      presetId: "tier-1",
+    });
+  });
+
+  it("rejects combining --preset and --target", async () => {
+    await seedConfig();
+    const streams = captureStreams();
+
+    const exitCode = await runBurnCommand({
+      args: [
+        "--provider",
+        "anthropic",
+        "--preset",
+        "tier-1",
+        "--target",
+        "100",
+      ],
+      io: { stdout: streams.stdout, stderr: streams.stderr },
+      homeDir,
+      disableParentWatch: true,
+    });
+
+    expect(exitCode).toBe(2);
+    expect(streams.collected().stderr).toContain("--preset or --target");
+  });
 });

--- a/tests/unit/presets.test.ts
+++ b/tests/unit/presets.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  burnPresets,
+  getBurnPreset,
+  presetIdSchema,
+  presetIdValues,
+} from "@token-burner/shared";
+
+describe("burn presets", () => {
+  it("exposes one entry per preset id with a strictly increasing target", () => {
+    expect(burnPresets.map((preset) => preset.id)).toEqual([...presetIdValues]);
+
+    const targets = burnPresets.map((preset) => preset.targetTokens);
+    for (let index = 1; index < targets.length; index += 1) {
+      expect(targets[index]).toBeGreaterThan(targets[index - 1]);
+    }
+  });
+
+  it("getBurnPreset returns the expected preset", () => {
+    for (const id of presetIdValues) {
+      const preset = getBurnPreset(id);
+      expect(preset.id).toBe(id);
+      expect(preset.targetTokens).toBeGreaterThan(0);
+      expect(preset.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("preset ids pass the shared zod schema", () => {
+    for (const id of presetIdValues) {
+      expect(() => presetIdSchema.parse(id)).not.toThrow();
+    }
+    expect(() => presetIdSchema.parse("tier-7")).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- 3 tiers in packages/shared/src/presets.ts (amuse-bouche 25k, statement piece 250k, couture run 2.5M) with labels + blurbs for chunk 6 homepage
- cli burn accepts --preset tier-1|tier-2|tier-3, resolves to target + presetId; --preset/--target are mutually exclusive
- openai adapter using openai sdk; same contract as anthropic
- OPENAI_API_KEY is the only credential source

## Test plan
- [x] 5 new unit tests, 60/60 suite green
- [x] typecheck + build clean (agent-cli + site)
- [ ] openai burn smoke TBD — structurally identical to the anthropic path that was live-smoked in chunk 4; real first burn will validate the model string once user confirms openai billing