### PR TITLE
feat(chunk-6a): homepage leaderboards + live feed

### DIFF
--- a/apps/site/src/app/_components/leaderboard-section.tsx
+++ b/apps/site/src/app/_components/leaderboard-section.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+
+import { providerValues, type ProviderId } from "@token-burner/shared";
+
+import type { ProviderSplitLeaderboard } from "../../lib/db/queries";
+
+export type LeaderboardSectionProps = {
+  title: string;
+  leaderboard: ProviderSplitLeaderboard;
+};
+
+const providerLabels: Record<ProviderId, string> = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+};
+
+const formatTokens = (n: number): string =>
+  n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+
+export function LeaderboardSection({ title, leaderboard }: LeaderboardSectionProps) {
+  return (
+    <section className="w-full">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-zinc-500">
+        {title}
+      </h2>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {providerValues.map((provider) => {
+          const entries = leaderboard[provider];
+          return (
+            <div
+              key={provider}
+              className="rounded-2xl border border-zinc-200 p-5 dark:border-zinc-800"
+            >
+              <div className="mb-3 flex items-baseline justify-between">
+                <h3 className="text-lg font-semibold">
+                  {providerLabels[provider]}
+                </h3>
+                <span className="text-xs uppercase tracking-widest text-zinc-500">
+                  billed tokens
+                </span>
+              </div>
+              {entries.length === 0 ? (
+                <p className="text-sm text-zinc-500">nothing burned yet.</p>
+              ) : (
+                <ol className="flex flex-col gap-2">
+                  {entries.map((entry) => (
+                    <li
+                      key={entry.humanId}
+                      className="flex items-center justify-between gap-4 border-b border-zinc-100 pb-2 last:border-none last:pb-0 dark:border-zinc-900"
+                    >
+                      <span className="flex min-w-0 items-center gap-3">
+                        <span className="w-6 text-right font-mono text-xs text-zinc-500">
+                          {entry.rank}
+                        </span>
+                        <span className="truncate">
+                          <Link
+                            href={`/u/${entry.handle}`}
+                            className="font-medium hover:underline"
+                          >
+                            {entry.avatarUrl} {entry.handle}
+                          </Link>
+                        </span>
+                      </span>
+                      <span className="shrink-0 font-mono text-sm">
+                        {formatTokens(entry.totalBilledTokens)}
+                      </span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/site/src/app/_components/live-burn-feed.tsx
+++ b/apps/site/src/app/_components/live-burn-feed.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+
+import type { ProviderId } from "@token-burner/shared";
+
+import type { LiveBurnFeedEntry } from "../../lib/db/queries";
+
+export type LiveBurnFeedProps = {
+  entries: LiveBurnFeedEntry[];
+};
+
+const providerLabels: Record<ProviderId, string> = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+};
+
+const formatTokens = (n: number): string =>
+  n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+
+const percent = (consumed: number, target: number): number => {
+  if (target <= 0) return 0;
+  return Math.min(100, Math.round((consumed / target) * 100));
+};
+
+export function LiveBurnFeed({ entries }: LiveBurnFeedProps) {
+  return (
+    <section className="w-full">
+      <div className="mb-4 flex items-baseline justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-zinc-500">
+          currently burning
+        </h2>
+        <span className="text-xs text-zinc-500">
+          {entries.length} active
+        </span>
+      </div>
+      {entries.length === 0 ? (
+        <p className="rounded-2xl border border-zinc-200 p-6 text-sm text-zinc-500 dark:border-zinc-800">
+          no active burns. start one from the CLI.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {entries.map((entry) => {
+            const pct = percent(
+              entry.billedTokensConsumed,
+              entry.requestedBilledTokenTarget,
+            );
+            return (
+              <li
+                key={entry.burnId}
+                className="rounded-2xl border border-zinc-200 p-4 dark:border-zinc-800"
+              >
+                <div className="flex items-baseline justify-between gap-4">
+                  <div className="min-w-0">
+                    <p className="font-medium">
+                      {entry.avatarUrl}{" "}
+                      <Link
+                        href={`/u/${entry.handle}`}
+                        className="hover:underline"
+                      >
+                        {entry.handle}
+                      </Link>
+                      {" — "}
+                      <Link
+                        href={`/burns/${entry.burnId}`}
+                        className="text-xs text-zinc-500 hover:underline"
+                      >
+                        watch burn
+                      </Link>
+                    </p>
+                    <p className="text-xs text-zinc-500">
+                      {providerLabels[entry.provider]} · {entry.model}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-mono text-lg">
+                      {formatTokens(entry.billedTokensConsumed)}
+                    </p>
+                    <p className="text-xs text-zinc-500">
+                      / {formatTokens(entry.requestedBilledTokenTarget)}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-900">
+                  <div
+                    className="h-full bg-zinc-900 dark:bg-zinc-100"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/site/src/app/page.tsx
+++ b/apps/site/src/app/page.tsx
@@ -1,47 +1,76 @@
+import {
+  getLiveBurnFeed,
+  getProviderAllTimeLeaderboard,
+  getProviderDailyLeaderboard,
+  getProviderWeeklyLeaderboard,
+} from "../lib/db/queries";
 import { ClaimCodePanel } from "./_components/claim-code-panel";
+import { LeaderboardSection } from "./_components/leaderboard-section";
+import { LiveBurnFeed } from "./_components/live-burn-feed";
 
 export const dynamic = "force-dynamic";
 
-export default function HomePage() {
+export default async function HomePage() {
   const appUrl =
     process.env.NEXT_PUBLIC_APP_URL ?? "https://token-burner-seven.vercel.app";
 
+  const [daily, weekly, allTime, liveFeed] = await Promise.all([
+    getProviderDailyLeaderboard({ limit: 10 }),
+    getProviderWeeklyLeaderboard({ limit: 10 }),
+    getProviderAllTimeLeaderboard({ limit: 10 }),
+    getLiveBurnFeed({ limit: 10 }),
+  ]);
+
   return (
-    <main className="flex flex-1 flex-col items-center gap-10 px-6 py-16">
-      <header className="flex max-w-2xl flex-col gap-3 text-center">
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 py-16">
+      <header className="flex flex-col gap-3 text-center">
         <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">
           a public venue for wasting tokens
         </p>
         <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
           token-burner
         </h1>
-        <p className="text-base text-zinc-500">
-          claim an identity here. burn from your CLI. climb the provider-split
-          leaderboards. the site never touches your provider keys.
+        <p className="mx-auto max-w-xl text-base text-zinc-500">
+          claim an identity here. burn from your CLI. climb the
+          provider-split leaderboards. the site never touches your provider
+          keys.
         </p>
       </header>
 
-      <section className="w-full max-w-2xl rounded-2xl border border-zinc-200 p-6 dark:border-zinc-800">
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-widest text-zinc-500">
-          step 1 — get a claim code
-        </h2>
-        <ClaimCodePanel />
-      </section>
+      <LeaderboardSection title="all time" leaderboard={allTime} />
+      <LeaderboardSection title="this week" leaderboard={weekly} />
+      <LeaderboardSection title="today" leaderboard={daily} />
 
-      <section className="w-full max-w-2xl rounded-2xl border border-zinc-200 p-6 dark:border-zinc-800">
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-widest text-zinc-500">
-          step 2 — paste into your CLI agent
+      <LiveBurnFeed entries={liveFeed} />
+
+      <section className="rounded-2xl border border-zinc-200 p-6 dark:border-zinc-800">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.3em] text-zinc-500">
+          onboard a new burner
         </h2>
-        <pre className="whitespace-pre-wrap break-words rounded-lg bg-zinc-100 p-4 text-sm text-zinc-800 dark:bg-zinc-900 dark:text-zinc-200">
+        <div className="flex flex-col gap-6">
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-widest text-zinc-500">
+              step 1 — mint a one-time claim code
+            </p>
+            <ClaimCodePanel />
+          </div>
+          <div>
+            <p className="mb-2 text-xs uppercase tracking-widest text-zinc-500">
+              step 2 — paste into your CLI agent
+            </p>
+            <pre className="whitespace-pre-wrap break-words rounded-lg bg-zinc-100 p-4 text-sm text-zinc-800 dark:bg-zinc-900 dark:text-zinc-200">
 {`read ${appUrl}/skill.md then register me on token-burner with the claim code i will paste next. pick a short handle and a single-emoji avatar. store the owner token locally.`}
-        </pre>
-        <p className="mt-3 text-xs text-zinc-500">
-          the agent will fetch the bootstrap doc, call the register endpoint,
-          and save the reusable owner token to your local machine.
-        </p>
+            </pre>
+            <p className="mt-3 text-xs text-zinc-500">
+              the agent fetches the bootstrap doc, calls the register
+              endpoint, and saves the reusable owner token to your local
+              machine. provider keys stay local.
+            </p>
+          </div>
+        </div>
       </section>
 
-      <footer className="mt-auto text-xs text-zinc-500">
+      <footer className="pt-6 text-center text-xs text-zinc-500">
         no site login. no stored API keys. burns stop when your CLI stops.
       </footer>
     </main>


### PR DESCRIPTION
## Summary
- homepage now SSRs all-time / weekly / daily leaderboards split by provider (openai + anthropic)
- live burn feed with progress bars for every active burn
- claim-code + onboarding prompt moved below boards per design priority
- no realtime wiring yet (chunk 6c)

## Test plan
- [x] 60/60 tests, typecheck, lint, next build clean
- [ ] smoke test on prod after merge