### PR TITLE
feat(chunk-6c): supabase realtime + anon rls hardening

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.104.0",
     "@token-burner/shared": "file:../../packages/shared",
     "drizzle-orm": "^0.44.7",
     "next": "16.2.4",
@@ -32,13 +33,13 @@
     "typescript": "^5"
   },
   "optionalDependencies": {
-    "lightningcss-linux-x64-gnu": "*",
-    "lightningcss-linux-arm64-gnu": "*",
-    "lightningcss-darwin-x64": "*",
-    "lightningcss-darwin-arm64": "*",
-    "@tailwindcss/oxide-linux-x64-gnu": "*",
-    "@tailwindcss/oxide-linux-arm64-gnu": "*",
+    "@tailwindcss/oxide-darwin-arm64": "*",
     "@tailwindcss/oxide-darwin-x64": "*",
-    "@tailwindcss/oxide-darwin-arm64": "*"
+    "@tailwindcss/oxide-linux-arm64-gnu": "*",
+    "@tailwindcss/oxide-linux-x64-gnu": "*",
+    "lightningcss-darwin-arm64": "*",
+    "lightningcss-darwin-x64": "*",
+    "lightningcss-linux-arm64-gnu": "*",
+    "lightningcss-linux-x64-gnu": "*"
   }
 }

--- a/apps/site/src/app/_components/burn-live-counter.tsx
+++ b/apps/site/src/app/_components/burn-live-counter.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { BurnStatus } from "@token-burner/shared";
+
+import { getSupabaseBrowserClient } from "../../lib/supabase-browser";
+
+type BurnRow = {
+  billed_tokens_consumed: number;
+  status: BurnStatus;
+};
+
+const activeStatuses = new Set<BurnStatus>(["queued", "running", "stopping"]);
+
+export type BurnLiveCounterProps = {
+  burnId: string;
+  initialBilledTokens: number;
+  initialStatus: BurnStatus;
+  requestedBilledTokenTarget: number;
+};
+
+const formatTokens = (n: number): string =>
+  n.toLocaleString("en-US", { maximumFractionDigits: 0 });
+
+const percent = (consumed: number, target: number): number => {
+  if (target <= 0) return 0;
+  return Math.min(100, (consumed / target) * 100);
+};
+
+export function BurnLiveCounter({
+  burnId,
+  initialBilledTokens,
+  initialStatus,
+  requestedBilledTokenTarget,
+}: BurnLiveCounterProps) {
+  const [billedTokens, setBilledTokens] = useState(initialBilledTokens);
+  const [status, setStatus] = useState<BurnStatus>(initialStatus);
+
+  useEffect(() => {
+    if (!activeStatuses.has(status)) {
+      return;
+    }
+
+    const supabase = getSupabaseBrowserClient();
+    const channel = supabase
+      .channel(`public:burns:${burnId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "burns",
+          filter: `id=eq.${burnId}`,
+        },
+        (payload) => {
+          const row = payload.new as BurnRow;
+          setBilledTokens(row.billed_tokens_consumed);
+          setStatus(row.status);
+        },
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [burnId, status]);
+
+  const pct = percent(billedTokens, requestedBilledTokenTarget);
+  const isActive = activeStatuses.has(status);
+
+  return (
+    <section className="flex flex-col items-center gap-4 text-center">
+      <p className="font-mono text-6xl sm:text-7xl">
+        {formatTokens(billedTokens)}
+      </p>
+      <p className="text-sm text-zinc-500">
+        of {formatTokens(requestedBilledTokenTarget)} billed tokens (
+        {pct.toFixed(1)}%) · <span className="font-mono">{status}</span>
+        {isActive ? " · live" : ""}
+      </p>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-900">
+        <div
+          className="h-full bg-zinc-900 transition-[width] duration-500 ease-out dark:bg-zinc-100"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/site/src/app/_components/burns-realtime-refresher.tsx
+++ b/apps/site/src/app/_components/burns-realtime-refresher.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import { getSupabaseBrowserClient } from "../../lib/supabase-browser";
+
+const debounceMs = 1_500;
+
+export function BurnsRealtimeRefresher(): null {
+  const router = useRouter();
+
+  useEffect(() => {
+    const supabase = getSupabaseBrowserClient();
+    let pendingRefresh: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleRefresh = () => {
+      if (pendingRefresh) return;
+      pendingRefresh = setTimeout(() => {
+        pendingRefresh = null;
+        router.refresh();
+      }, debounceMs);
+    };
+
+    const channel = supabase
+      .channel("public:burns")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "burns" },
+        scheduleRefresh,
+      )
+      .subscribe();
+
+    return () => {
+      if (pendingRefresh) {
+        clearTimeout(pendingRefresh);
+      }
+      supabase.removeChannel(channel);
+    };
+  }, [router]);
+
+  return null;
+}

--- a/apps/site/src/app/burns/[burnId]/page.tsx
+++ b/apps/site/src/app/burns/[burnId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import type { ProviderId } from "@token-burner/shared";
 
 import { getPublicBurnById } from "../../../lib/db/queries";
+import { BurnLiveCounter } from "../../_components/burn-live-counter";
 
 export const dynamic = "force-dynamic";
 
@@ -11,9 +12,6 @@ const providerLabels: Record<ProviderId, string> = {
   openai: "OpenAI",
   anthropic: "Anthropic",
 };
-
-const formatTokens = (n: number): string =>
-  n.toLocaleString("en-US", { maximumFractionDigits: 0 });
 
 const formatDateTime = (date: Date): string =>
   date.toLocaleString(undefined, {
@@ -24,11 +22,6 @@ const formatDateTime = (date: Date): string =>
     minute: "2-digit",
     second: "2-digit",
   });
-
-const percent = (consumed: number, target: number): number => {
-  if (target <= 0) return 0;
-  return Math.min(100, (consumed / target) * 100);
-};
 
 export default async function BurnPage({
   params,
@@ -42,7 +35,6 @@ export default async function BurnPage({
     notFound();
   }
 
-  const pct = percent(burn.billedTokensConsumed, burn.requestedBilledTokenTarget);
   const isActive =
     burn.status === "queued" ||
     burn.status === "running" ||
@@ -65,21 +57,12 @@ export default async function BurnPage({
         </p>
       </header>
 
-      <section className="flex flex-col items-center gap-4 text-center">
-        <p className="font-mono text-6xl sm:text-7xl">
-          {formatTokens(burn.billedTokensConsumed)}
-        </p>
-        <p className="text-sm text-zinc-500">
-          of {formatTokens(burn.requestedBilledTokenTarget)} billed tokens (
-          {pct.toFixed(1)}%)
-        </p>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-900">
-          <div
-            className="h-full bg-zinc-900 dark:bg-zinc-100"
-            style={{ width: `${pct}%` }}
-          />
-        </div>
-      </section>
+      <BurnLiveCounter
+        burnId={burn.burnId}
+        initialBilledTokens={burn.billedTokensConsumed}
+        initialStatus={burn.status}
+        requestedBilledTokenTarget={burn.requestedBilledTokenTarget}
+      />
 
       <section className="rounded-2xl border border-zinc-200 p-5 text-sm dark:border-zinc-800">
         <dl className="grid grid-cols-2 gap-y-2">

--- a/apps/site/src/app/page.tsx
+++ b/apps/site/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
   getProviderDailyLeaderboard,
   getProviderWeeklyLeaderboard,
 } from "../lib/db/queries";
+import { BurnsRealtimeRefresher } from "./_components/burns-realtime-refresher";
 import { ClaimCodePanel } from "./_components/claim-code-panel";
 import { LeaderboardSection } from "./_components/leaderboard-section";
 import { LiveBurnFeed } from "./_components/live-burn-feed";
@@ -23,6 +24,7 @@ export default async function HomePage() {
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-12 px-6 py-16">
+      <BurnsRealtimeRefresher />
       <header className="flex flex-col gap-3 text-center">
         <p className="text-xs uppercase tracking-[0.4em] text-zinc-500">
           a public venue for wasting tokens

--- a/apps/site/src/lib/supabase-browser.ts
+++ b/apps/site/src/lib/supabase-browser.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import {
+  createClient,
+  type SupabaseClient,
+} from "@supabase/supabase-js";
+
+let browserClient: SupabaseClient | null = null;
+
+export const getSupabaseBrowserClient = (): SupabaseClient => {
+  if (browserClient) {
+    return browserClient;
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set for the browser supabase client.",
+    );
+  }
+
+  browserClient = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false },
+    realtime: { params: { eventsPerSecond: 5 } },
+  });
+
+  return browserClient;
+};

--- a/drizzle/0003_rls_and_realtime.sql
+++ b/drizzle/0003_rls_and_realtime.sql
@@ -1,0 +1,46 @@
+-- Defense-in-depth for the browser anon key.
+--
+-- Supabase grants the `anon` role full SELECT/INSERT/UPDATE/DELETE on every
+-- table in the public schema by default. That means once we publish
+-- NEXT_PUBLIC_SUPABASE_ANON_KEY to the browser, any visitor could rewrite
+-- owner tokens or claim codes unless we lock it down.
+--
+-- Strategy:
+--   1. Enable RLS on all tables. Without a policy, every role except
+--      postgres (which has BYPASSRLS) is denied.
+--   2. Add permissive SELECT policies on the three public-facing tables:
+--      humans, burns, burn_events. The homepage + profile + burn page
+--      already treat them as public.
+--   3. Revoke the default write grants from anon so policies can't be
+--      bypassed even if a SELECT policy is added later.
+--   4. Revoke anon SELECT on the private tables so realtime never leaks
+--      claim_codes / owner_tokens / agent_installations rows.
+--   5. Publish burns, burn_events, humans to supabase_realtime so the
+--      site can subscribe.
+
+alter table humans enable row level security;
+alter table agent_installations enable row level security;
+alter table claim_codes enable row level security;
+alter table owner_tokens enable row level security;
+alter table burns enable row level security;
+alter table burn_events enable row level security;
+
+create policy humans_public_select on humans
+  for select to anon, authenticated
+  using (true);
+
+create policy burns_public_select on burns
+  for select to anon, authenticated
+  using (true);
+
+create policy burn_events_public_select on burn_events
+  for select to anon, authenticated
+  using (true);
+
+revoke insert, update, delete, truncate, references, trigger on
+  humans, agent_installations, claim_codes, owner_tokens, burns, burn_events
+  from anon;
+
+revoke select on claim_codes, owner_tokens, agent_installations from anon;
+
+alter publication supabase_realtime add table humans, burns, burn_events;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "name": "@token-burner/site",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.104.0",
         "@token-burner/shared": "file:../../packages/shared",
         "drizzle-orm": "^0.44.7",
         "next": "16.2.4",
@@ -4012,10 +4013,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "apps/site/node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
-    },
     "apps/site/node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -5178,6 +5175,92 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.0.tgz",
+      "integrity": "sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.104.0.tgz",
+      "integrity": "sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.104.0.tgz",
+      "integrity": "sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.104.0.tgz",
+      "integrity": "sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.104.0.tgz",
+      "integrity": "sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.104.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.104.0.tgz",
+      "integrity": "sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.104.0",
+        "@supabase/functions-js": "2.104.0",
+        "@supabase/postgrest-js": "2.104.0",
+        "@supabase/realtime-js": "2.104.0",
+        "@supabase/storage-js": "2.104.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
@@ -5292,6 +5375,15 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -6070,6 +6162,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/immutable": {
@@ -6894,6 +6995,12 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7125,6 +7232,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/tests/integration/burns-api.test.ts
+++ b/tests/integration/burns-api.test.ts
@@ -58,7 +58,13 @@ const createTestDatabase = async (): Promise<TestContext> => {
 
   const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
+    migrationSql
+      .replace(/--[^\n]*/g, "")
+      .replace(/create extension if not exists "pgcrypto";\n\n?/gi, "")
+      .replace(/^alter table[^;]+enable row level security\s*;/gim, "")
+      .replace(/^create policy[^;]+;/gim, "")
+      .replace(/^revoke[^;]+;/gim, "")
+      .replace(/^alter publication[^;]+;/gim, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();

--- a/tests/integration/db-queries.test.ts
+++ b/tests/integration/db-queries.test.ts
@@ -64,7 +64,13 @@ const createTestDatabase = async (): Promise<TestContext> => {
 
   const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
+    migrationSql
+      .replace(/--[^\n]*/g, "")
+      .replace(/create extension if not exists "pgcrypto";\n\n?/gi, "")
+      .replace(/^alter table[^;]+enable row level security\s*;/gim, "")
+      .replace(/^create policy[^;]+;/gim, "")
+      .replace(/^revoke[^;]+;/gim, "")
+      .replace(/^alter publication[^;]+;/gim, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();

--- a/tests/integration/onboarding.test.ts
+++ b/tests/integration/onboarding.test.ts
@@ -51,7 +51,13 @@ const createTestDatabase = async (): Promise<TestContext> => {
 
   const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
+    migrationSql
+      .replace(/--[^\n]*/g, "")
+      .replace(/create extension if not exists "pgcrypto";\n\n?/gi, "")
+      .replace(/^alter table[^;]+enable row level security\s*;/gim, "")
+      .replace(/^create policy[^;]+;/gim, "")
+      .replace(/^revoke[^;]+;/gim, "")
+      .replace(/^alter publication[^;]+;/gim, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();

--- a/tests/integration/server-auth-housekeeping.test.ts
+++ b/tests/integration/server-auth-housekeeping.test.ts
@@ -59,7 +59,13 @@ const createTestDatabase = async (): Promise<TestContext> => {
 
   const migrationSql = await readAllMigrationsSql();
   memoryDatabase.public.none(
-    migrationSql.replace(/create extension if not exists "pgcrypto";\n\n?/gi, ""),
+    migrationSql
+      .replace(/--[^\n]*/g, "")
+      .replace(/create extension if not exists "pgcrypto";\n\n?/gi, "")
+      .replace(/^alter table[^;]+enable row level security\s*;/gim, "")
+      .replace(/^create policy[^;]+;/gim, "")
+      .replace(/^revoke[^;]+;/gim, "")
+      .replace(/^alter publication[^;]+;/gim, ""),
   );
 
   const adapter = memoryDatabase.adapters.createPg();


### PR DESCRIPTION
## Summary
- **security fix:** supabase's default grants give the anon role full INSERT/UPDATE/DELETE on every public table including owner_tokens and claim_codes. migration 0003 enables RLS everywhere, adds permissive SELECT policies only on humans/burns/burn_events, and revokes anon's write grants. owner_tokens + claim_codes + agent_installations are no longer reachable via the browser key.
- burn detail page has a realtime counter that updates in place as heartbeat/events land
- homepage debounces router.refresh() on any burns-table change so leaderboards + live feed update without reload
- server-side queries still work unchanged — postgres role has BYPASSRLS

## Test plan
- [x] 60/60 tests green (pg-mem ignores RLS/policy/publication statements via a strip pass)
- [x] next build clean
- [x] migration applied to live supabase, publication has humans/burns/burn_events
- [ ] post-merge: live-burn smoke to see counter move in real time