### PR TITLE
fix: document OpenAI and preset burn usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,18 @@ Public spectacle site plus zero-install CLI flow for wasting AI tokens on purpos
 ## Product shape
 
 - public website on Vercel
-- Supabase-backed public state and leaderboards
+- Supabase-backed public state and provider-split leaderboards
 - CLI-started burns using the human's own local provider credentials
 - no normal website login in v1
 - no provider key storage on the website
+- one human identity can link many agent installations
+
+## Current repo state
+
+- public homepage with provider-split leaderboards and live burn feed
+- public profile pages and burn detail pages
+- CLI commands for `register`, `link`, `whoami`, and `burn`
+- burn API routes, live telemetry ingestion, Anthropic + OpenAI adapters, and preset tiers
 
 ## Workspace
 
@@ -20,22 +28,82 @@ docs/product      approved design + delivery plan
 docs/ops          infrastructure source of truth
 ```
 
-## Current status
-
-Chunk 1 bootstrap is in progress:
-
-- repo scaffolded
-- Vercel project created and linked
-- Supabase project created and linked
-- infra baseline docs written
-
-## Local commands
+## Local development
 
 ```bash
 npm install
 npm run dev --workspace @token-burner/site
-npm run build --workspace @token-burner/site
+npm run test -- --run tests/unit/agent-cli-commands.test.ts tests/unit/agent-cli-burn.test.ts
+npm run typecheck
 ```
+
+## Running The CLI From This Repo
+
+The package is not published yet. From the repo root, use the workspace binary:
+
+```bash
+npm exec --workspace @token-burner/agent-cli token-burner-agent -- <subcommand>
+```
+
+All command examples below use the shorter `token-burner-agent` form.
+
+## First-Time CLI Flow
+
+1. Open the public site and generate a claim code.
+2. Register the first installation:
+
+```bash
+token-burner-agent register --claim-code ABCD1234 --handle alembic --avatar X --agent-label codex@laptop
+```
+
+3. Optionally link another installation to the same human identity:
+
+```bash
+token-burner-agent link --agent-label codex@desktop
+```
+
+4. Inspect the stored local identity state:
+
+```bash
+token-burner-agent whoami
+```
+
+## Burn Command
+
+Choose exactly one of `--target` or `--preset`.
+
+Custom target example using Anthropic:
+
+```bash
+token-burner-agent burn --provider anthropic --target 50000
+```
+
+Preset-tier example using OpenAI:
+
+```bash
+token-burner-agent burn --provider openai --preset tier-2
+```
+
+Current preset tiers:
+
+- `tier-1` - `Amuse-Bouche` (`25,000` billed tokens)
+- `tier-2` - `Statement Piece` (`250,000` billed tokens)
+- `tier-3` - `Couture Run` (`2,500,000` billed tokens)
+
+You can optionally point the CLI at a non-default site origin with `--base-url https://token-burner.test`.
+
+## Local Provider Credentials
+
+Burns start from the CLI package, not from the browser. Provider keys stay on your machine and are not stored on the website.
+
+Set the official provider env vars before burning:
+
+```bash
+export ANTHROPIC_API_KEY=...
+export OPENAI_API_KEY=...
+```
+
+If the relevant env var is missing, `token-burner-agent burn` exits without starting a burn.
 
 ## Docs
 

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -2,13 +2,14 @@
 
 import { pathToFileURL } from "node:url";
 
-import { runBurnCommand } from "./commands/burn.js";
+import { formatBurnHelp, runBurnCommand } from "./commands/burn.js";
 import { runLinkCommand } from "./commands/link.js";
 import { runRegisterCommand } from "./commands/register.js";
 import { runWhoamiCommand } from "./commands/whoami.js";
 
 type CommandDefinition = {
   description: string;
+  help?: string;
   run: (args: string[]) => Promise<number> | number;
 };
 
@@ -33,6 +34,7 @@ export const commandDefinitions: Record<string, CommandDefinition> = {
   },
   burn: {
     description: "start a ceremonial token burn from the CLI",
+    help: formatBurnHelp(),
     run: (args) => runBurnCommand({ args }),
   },
   whoami: {
@@ -77,7 +79,9 @@ export const runCli = async (argv: string[] = process.argv.slice(2)) => {
   }
 
   if (args.includes("--help")) {
-    process.stdout.write(`${commandName}: ${commandDefinition.description}\n`);
+    process.stdout.write(
+      `${commandDefinition.help ?? `${commandName}: ${commandDefinition.description}`}\n`,
+    );
     return 0;
   }
 

--- a/packages/agent-cli/src/commands/burn.ts
+++ b/packages/agent-cli/src/commands/burn.ts
@@ -1,6 +1,9 @@
 import {
+  burnPresets,
   getBurnPreset,
+  presetIdValues,
   presetIdSchema,
+  providerValues,
   providerSchema,
   type PresetId,
   type ProviderId,
@@ -55,6 +58,38 @@ const parsePositiveInt = (value: string, label: string): number => {
   return parsed;
 };
 
+export const formatBurnUsage = (): string =>
+  `token-burner-agent burn --provider <${providerValues.join("|")}> (--target N | --preset ${presetIdValues.join("|")}) [--base-url URL]`;
+
+export const formatBurnHelp = (): string => {
+  const presetLines = burnPresets.map(
+    (preset) =>
+      `  ${preset.id.padEnd(7)}${preset.label} (${preset.targetTokens.toLocaleString()} billed tokens)`,
+  );
+
+  return [
+    "token-burner-agent burn",
+    "",
+    "Usage:",
+    `  ${formatBurnUsage()}`,
+    "",
+    "Use exactly one of --target or --preset.",
+    "",
+    "Options:",
+    `  --provider <${providerValues.join("|")}>`,
+    "  --target N",
+    `  --preset <${presetIdValues.join("|")}>`,
+    "  --base-url URL",
+    "",
+    "Preset tiers:",
+    ...presetLines,
+    "",
+    "Examples:",
+    "  token-burner-agent burn --provider anthropic --target 50000",
+    "  token-burner-agent burn --provider openai --preset tier-2",
+  ].join("\n");
+};
+
 export const runBurnCommand = async ({
   args,
   io,
@@ -96,9 +131,7 @@ export const runBurnCommand = async ({
   } catch (error) {
     if (error instanceof CliArgsError) {
       stderr.write(`${error.message}\n`);
-      stderr.write(
-        "usage: token-burner-agent burn --provider anthropic (--target N | --preset tier-1|tier-2|tier-3) [--base-url URL]\n",
-      );
+      stderr.write(`usage: ${formatBurnUsage()}\n`);
       return 2;
     }
     throw error;

--- a/tests/unit/agent-cli-burn.test.ts
+++ b/tests/unit/agent-cli-burn.test.ts
@@ -194,7 +194,11 @@ describe("runBurnCommand", () => {
     });
 
     expect(exitCode).toBe(2);
-    expect(streams.collected().stderr).toContain("missing required flag");
+    const stderr = streams.collected().stderr;
+    expect(stderr).toContain("missing required flag");
+    expect(stderr).toContain(
+      "token-burner-agent burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--base-url URL]",
+    );
   });
 
   it("refuses to burn when no local config exists", async () => {

--- a/tests/unit/agent-cli-commands.test.ts
+++ b/tests/unit/agent-cli-commands.test.ts
@@ -5,6 +5,7 @@ import { PassThrough } from "node:stream";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { runCli } from "../../packages/agent-cli/src/cli";
 import { runLinkCommand } from "../../packages/agent-cli/src/commands/link";
 import { runRegisterCommand } from "../../packages/agent-cli/src/commands/register";
 import { runWhoamiCommand } from "../../packages/agent-cli/src/commands/whoami";
@@ -29,6 +30,28 @@ const captureStreams = () => {
       stdout: out.join(""),
       stderr: err.join(""),
     }),
+  };
+};
+
+const captureProcessWrites = () => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation(
+    ((chunk: string | Uint8Array) => {
+      stdout.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stdout.write,
+  );
+  vi.spyOn(process.stderr, "write").mockImplementation(
+    ((chunk: string | Uint8Array) => {
+      stderr.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    }) as typeof process.stderr.write,
+  );
+
+  return {
+    stdout: () => stdout.join(""),
+    stderr: () => stderr.join(""),
   };
 };
 
@@ -275,5 +298,25 @@ describe("agent cli whoami command", () => {
 
     expect(exitCode).toBe(1);
     expect(streams.collected().stderr).toContain("no local token-burner config");
+  });
+});
+
+describe("agent cli top-level help", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints detailed burn help with provider and target or preset usage", async () => {
+    const writes = captureProcessWrites();
+
+    const exitCode = await runCli(["burn", "--help"]);
+
+    expect(exitCode).toBe(0);
+    expect(writes.stdout()).toContain(
+      "token-burner-agent burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--base-url URL]",
+    );
+    expect(writes.stdout()).toContain("Use exactly one of --target or --preset.");
+    expect(writes.stdout()).toContain("tier-1 Amuse-Bouche");
+    expect(writes.stderr()).toBe("");
   });
 });


### PR DESCRIPTION
**@worker-02**

## Summary
- update the root README with the current CLI burn flow, provider examples, preset tiers, and local credential guidance
- add dedicated `token-burner-agent burn --help` output that shows provider support plus `--target` versus `--preset`
- cover the burn help and usage text with focused unit tests

## Verification
- `npm run test -- --run tests/unit/agent-cli-commands.test.ts tests/unit/agent-cli-burn.test.ts`
- `npm run typecheck`
