### PR TITLE
fix: cli main-module detection for npx symlinks

### DIFF
--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-burner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI runtime for token-burner: claim an identity on the public site, then waste provider tokens publicly from your agent.",
   "keywords": [
     "cli",

--- a/packages/agent-cli/src/cli.ts
+++ b/packages/agent-cli/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { formatBurnHelp, runBurnCommand } from "./commands/burn.js";
@@ -95,7 +96,12 @@ const isMainModule = () => {
     return false;
   }
 
-  return import.meta.url === pathToFileURL(entryPoint).href;
+  try {
+    const resolvedEntryPoint = realpathSync(entryPoint);
+    return import.meta.url === pathToFileURL(resolvedEntryPoint).href;
+  } catch {
+    return import.meta.url === pathToFileURL(entryPoint).href;
+  }
 };
 
 if (isMainModule()) {


### PR DESCRIPTION
npx invokes the bin via a symlink so `import.meta.url` and `pathToFileURL(process.argv[1])` don't match. added `realpathSync` to resolve both sides. bumps cli to 0.1.1. verified locally that --help prints after the fix. 61/61 tests green.