### PR TITLE
chore: move onboard section above leaderboards

### DIFF
--- a/apps/site/src/app/page.tsx
+++ b/apps/site/src/app/page.tsx
@@ -52,12 +52,6 @@ export default async function HomePage() {
       <MarqueeBanner />
 
       <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 py-16">
-        <LeaderboardSection title="today" leaderboard={daily} />
-        <LeaderboardSection title="this week" leaderboard={weekly} />
-        <LeaderboardSection title="all time" leaderboard={allTime} />
-
-        <LiveBurnFeed entries={liveFeed} />
-
         <section className="border-2 border-ivory">
           <div className="flex items-end justify-between gap-4 border-b-2 border-ivory bg-ember px-6 py-3 text-ink">
             <h2 className="display text-2xl font-black uppercase tracking-tight sm:text-3xl">
@@ -92,6 +86,12 @@ avatar. store the owner token locally.`}
             </div>
           </div>
         </section>
+
+        <LeaderboardSection title="today" leaderboard={daily} />
+        <LeaderboardSection title="this week" leaderboard={weekly} />
+        <LeaderboardSection title="all time" leaderboard={allTime} />
+
+        <LiveBurnFeed entries={liveFeed} />
 
         <footer className="flex flex-col items-center gap-1 border-t-2 border-ivory pt-8 text-center">
           <p className="mono text-[0.6rem] uppercase tracking-[0.3em] text-bone">


### PR DESCRIPTION
## Summary
- Reorders homepage so the onboard section renders above today/week/all-time leaderboards and live burn feed.

## Test plan
- [ ] Verify on vercel preview that onboard appears first under the marquee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)