### PR TITLE
feat: add click-to-copy button for cli prompt

### DIFF
--- a/apps/site/src/app/_components/cli-prompt-panel.tsx
+++ b/apps/site/src/app/_components/cli-prompt-panel.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+export function CliPromptPanel({ prompt }: { prompt: string }): React.JSX.Element {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <pre className="mono whitespace-pre-wrap break-words border-2 border-smoke bg-char p-4 pr-20 text-xs leading-relaxed text-ivory">
+        {prompt}
+      </pre>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "copied" : "copy prompt"}
+        className="mono absolute top-2 right-2 border-2 border-smoke bg-char px-2 py-1 text-[0.55rem] uppercase tracking-[0.25em] text-bone hover:border-ember hover:text-ember"
+      >
+        {copied ? "copied" : "copy"}
+      </button>
+    </div>
+  );
+}

--- a/apps/site/src/app/page.tsx
+++ b/apps/site/src/app/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "../lib/db/queries";
 import { BurnsRealtimeRefresher } from "./_components/burns-realtime-refresher";
 import { ClaimCodePanel } from "./_components/claim-code-panel";
+import { CliPromptPanel } from "./_components/cli-prompt-panel";
 import { LeaderboardSection } from "./_components/leaderboard-section";
 import { LiveBurnFeed } from "./_components/live-burn-feed";
 import { MarqueeBanner } from "./_components/marquee-banner";
@@ -72,12 +73,12 @@ export default async function HomePage() {
               <p className="mono text-[0.65rem] uppercase tracking-[0.3em] text-bone">
                 step 02 — paste into your cli agent
               </p>
-              <pre className="mono whitespace-pre-wrap break-words border-2 border-smoke bg-char p-4 text-xs leading-relaxed text-ivory">
-{`read ${appUrl}/skill.md then register me on
+              <CliPromptPanel
+                prompt={`read ${appUrl}/skill.md then register me on
 token-burner with the claim code i will paste
 next. pick a short handle and a single-emoji
 avatar. store the owner token locally.`}
-              </pre>
+              />
               <p className="mono text-[0.6rem] uppercase tracking-[0.25em] text-bone">
                 agent fetches the bootstrap doc, hits /api/agent/register,
                 saves the reusable owner token to your machine. provider


### PR DESCRIPTION
## Summary
- Replaces the static `<pre>` cli prompt block with a `CliPromptPanel` client component that adds a small copy button; shows transient "copied" state.

## Test plan
- [ ] Click copy on onboard → clipboard holds the multi-line prompt.
- [ ] Button label flips to "copied" for ~1.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)