### PR TITLE
chore: move burning-now directly under onboard

### DIFF
--- a/apps/site/src/app/page.tsx
+++ b/apps/site/src/app/page.tsx
@@ -88,11 +88,11 @@ avatar. store the owner token locally.`}
           </div>
         </section>
 
+        <LiveBurnFeed entries={liveFeed} />
+
         <LeaderboardSection title="today" leaderboard={daily} />
         <LeaderboardSection title="this week" leaderboard={weekly} />
         <LeaderboardSection title="all time" leaderboard={allTime} />
-
-        <LiveBurnFeed entries={liveFeed} />
 
         <footer className="flex flex-col items-center gap-1 border-t-2 border-ivory pt-8 text-center">
           <p className="mono text-[0.6rem] uppercase tracking-[0.3em] text-bone">


### PR DESCRIPTION
## Summary
- Puts the live burn feed right under the onboard section so the \"in-flight action\" sits next to the call-to-action, above the historical leaderboards.

## Test plan
- [ ] After deploy, homepage order: header → marquee → onboard → burning now → today → this week → all time → footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)