### PR TITLE
feat: segmented-tabs toggle + portrait copy panel + specific storage

### DIFF
--- a/apps/site/public/skill.md
+++ b/apps/site/public/skill.md
@@ -32,7 +32,20 @@ body: { claimCode, publicHandle, avatar, agentLabel }
 → 409 if the claim code is invalid/expired/consumed
 ```
 
-Store `ownerToken` locally (per the agent's config path). It is reusable and is the credential for future burns and for linking more installations.
+Persist the returned identity to `~/.config/token-burner/config.json` (create parent dirs if missing, `chmod 600`) using exactly this shape:
+
+```json
+{
+  "humanId": "…",
+  "agentInstallationId": "…",
+  "ownerToken": "…",
+  "baseUrl": "https://token-burner-seven.vercel.app",
+  "publicHandle": "…",
+  "avatar": "…"
+}
+```
+
+The `ownerToken` is reusable — it is the credential for future burns and for linking more installations. Never commit this file and never send it to remote systems.
 
 ### Returning installation
 
@@ -49,7 +62,7 @@ Later chunks of the product define these; they require the owner token and retur
 
 ## Flow summary
 
-1. If the user has no local owner token: get a claim code from the site and call `/api/agent/register` with handle + avatar + agent label.
-2. If the user has a local owner token: call `/api/agent/link` with a new agent label to record this installation.
-3. Persist the owner token locally (never in the repo, never on the website).
+1. If `~/.config/token-burner/config.json` is missing: get a claim code from the site and call `/api/agent/register` with the handle + avatar the user gives you, plus an agent label for this installation.
+2. If the config file exists: call `/api/agent/link` with the stored `ownerToken` and a new agent label to record this installation.
+3. Write/update `~/.config/token-burner/config.json` in the shape shown above. Never commit it, never upload it.
 4. Start a burn using the owner token once provider credentials are available locally.

--- a/apps/site/src/app/_components/onboard-panel.tsx
+++ b/apps/site/src/app/_components/onboard-panel.tsx
@@ -13,10 +13,10 @@ type ClaimState =
   | { status: "ready"; code: string; expiresAt: string };
 
 const buildSignupPrompt = (appUrl: string, code: string): string =>
-  `read ${appUrl}/skill.md then register me on token-burner with claim code ${code}. ask me what public handle and single-emoji avatar i want — do not pick for me. store the reusable owner token locally.`;
+  `read ${appUrl}/skill.md then register me on token-burner with claim code ${code}. ask me what public handle and single-emoji avatar i want — do not pick for me. save the returned identity (publicHandle, avatar, ownerToken, humanId, agentInstallationId, baseUrl) to ~/.config/token-burner/config.json with mode 0600.`;
 
 const buildReturningPrompt = (appUrl: string): string =>
-  `read ${appUrl}/skill.md then link this installation to my existing token-burner identity. use the owner token saved at ~/.config/token-burner/config.json if present; if it is missing, ask me to paste it.`;
+  `read ${appUrl}/skill.md then link this installation to my existing token-burner identity. read the owner token from ~/.config/token-burner/config.json if present; if the file is missing, ask me to paste the owner token. then call /api/agent/link and update that same config file with the new agentInstallationId.`;
 
 export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element {
   const [mode, setMode] = useState<Mode>("new");
@@ -67,35 +67,52 @@ export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element 
     }
   };
 
-  const toggleLabel = mode === "new" ? "returning?" : "new burner?";
-  const toggleMode = () =>
-    setMode((current) => (current === "new" ? "returning" : "new"));
-
   return (
     <section className="border-2 border-ivory">
-      <div className="flex items-end justify-between gap-4 border-b-2 border-ivory bg-ember px-6 py-3 text-ink">
+      <div className="border-b-2 border-ivory bg-ember px-6 py-3 text-ink">
         <h2 className="display text-2xl font-black uppercase tracking-tight sm:text-3xl">
           onboard a burner
         </h2>
+      </div>
+
+      <div className="flex border-b-2 border-ivory">
         <button
           type="button"
-          onClick={toggleMode}
-          className="mono text-[0.65rem] uppercase tracking-[0.3em] hover:underline"
+          onClick={() => setMode("new")}
+          aria-pressed={mode === "new"}
+          className={`mono flex-1 border-r-2 border-ivory px-4 py-3 text-[0.7rem] uppercase tracking-[0.3em] ${
+            mode === "new"
+              ? "bg-ember text-ink"
+              : "bg-char text-bone hover:bg-smoke hover:text-ivory"
+          }`}
         >
-          {toggleLabel}
+          new burner
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("returning")}
+          aria-pressed={mode === "returning"}
+          className={`mono flex-1 px-4 py-3 text-[0.7rem] uppercase tracking-[0.3em] ${
+            mode === "returning"
+              ? "bg-ember text-ink"
+              : "bg-char text-bone hover:bg-smoke hover:text-ivory"
+          }`}
+        >
+          returning
         </button>
       </div>
-      <div className="flex flex-col gap-4 p-6">
+
+      <div className="flex flex-col items-center gap-4 p-6">
         {mode === "new" && claim.status !== "ready" ? (
-          <div className="flex flex-col gap-3">
-            <p className="mono text-[0.65rem] uppercase tracking-[0.3em] text-bone">
-              step · mint a one-time code, then copy the prompt into your cli agent
+          <div className="flex w-full max-w-sm flex-col items-center gap-3">
+            <p className="mono text-center text-[0.65rem] uppercase tracking-[0.3em] text-bone">
+              mint a one-time code, then paste the prompt into your cli agent
             </p>
             <button
               type="button"
               onClick={requestCode}
               disabled={claim.status === "loading"}
-              className="display self-start border-2 border-ember bg-ember px-6 py-3 text-sm font-black uppercase tracking-[0.25em] text-ink hover:bg-molten hover:border-molten disabled:opacity-50"
+              className="display border-2 border-ember bg-ember px-6 py-3 text-sm font-black uppercase tracking-[0.25em] text-ink hover:bg-molten hover:border-molten disabled:opacity-50"
             >
               {claim.status === "loading" ? "minting…" : "mint claim code"}
             </button>
@@ -106,7 +123,7 @@ export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element 
         ) : null}
 
         {mode === "new" && claim.status === "ready" ? (
-          <div className="border-2 border-ember bg-char px-5 py-4">
+          <div className="w-full max-w-sm border-2 border-ember bg-char px-5 py-4 text-center">
             <p className="mono text-[0.6rem] uppercase tracking-[0.3em] text-bone">
               one-time code · expires{" "}
               {new Date(claim.expiresAt).toLocaleTimeString()}
@@ -118,8 +135,8 @@ export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element 
         ) : null}
 
         {prompt ? (
-          <div className="relative">
-            <pre className="mono whitespace-pre-wrap break-words border-2 border-smoke bg-char p-4 pr-20 text-xs leading-relaxed text-ivory">
+          <div className="relative w-full max-w-sm">
+            <pre className="mono whitespace-pre-wrap break-words border-2 border-smoke bg-char p-4 pr-14 text-xs leading-relaxed text-ivory">
               {prompt}
             </pre>
             <button
@@ -136,17 +153,17 @@ export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element 
         {mode === "new" && claim.status === "ready" ? (
           <button
             type="button"
-            className="mono self-start text-[0.65rem] uppercase tracking-[0.3em] text-bone hover:text-ivory"
+            className="mono text-[0.65rem] uppercase tracking-[0.3em] text-bone hover:text-ivory"
             onClick={requestCode}
           >
             ↻ mint another
           </button>
         ) : null}
 
-        <p className="mono text-[0.6rem] uppercase tracking-[0.25em] text-bone">
+        <p className="mono w-full max-w-sm text-center text-[0.6rem] uppercase tracking-[0.25em] text-bone">
           {mode === "new"
-            ? "agent fetches the bootstrap doc, hits /api/agent/register, saves the reusable owner token to your machine. provider keys stay local."
-            : "agent reads the saved owner token and calls /api/agent/link to attach this installation. same identity, new machine."}
+            ? "agent reads the bootstrap skill, hits /api/agent/register, writes ~/.config/token-burner/config.json. provider keys stay local."
+            : "agent reads the saved owner token, calls /api/agent/link, updates the same config file with this installation."}
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Returning toggle is now a prominent segmented control under the section title (two tabs, full-width). The old text-link in the header was easy to miss.
- Copy-prompt block constrained to \`max-w-sm\` and centered — matches the portrait-oriented paste-me cards used by most agent onboarding flows.
- Prompt text + skill.md both specify \`~/.config/token-burner/config.json\` + the exact JSON shape instead of saying "store locally".

## Test plan
- [ ] Toggle between \"new burner\" and \"returning\" — active tab shows ember bg.
- [ ] New burner flow: mint → code + portrait prompt render; copy button copies full prompt including code + path.
- [ ] Returning flow: portrait prompt mentions \`~/.config/token-burner/config.json\`.
- [ ] \`curl /skill.md\` now contains the JSON schema block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)