### PR TITLE
feat: innies key routing + skill.md points agents at the cli

### DIFF
--- a/apps/site/public/skill.md
+++ b/apps/site/public/skill.md
@@ -10,29 +10,28 @@ The human has a token-burner claim code (or an owner token, for returning humans
 
 - Never store the human's provider API keys on any remote system. They stay local.
 - Never exceed the human's requested billed-token target. Stop conservatively under it.
-- Only call official provider APIs (OpenAI, Anthropic). No scraping, no bypass auth flows.
+- Only call official provider APIs (OpenAI, Anthropic). Innies-proxied keys (`in_live_*` / `in_test_*`) are allowed because they forward to those official APIs; nothing else.
 - One active burn per human at a time.
 - If this CLI session ends, the burn ends.
 
-## Endpoints
+## Recommended path: the `token-burner` npm CLI
 
-Base URL: `https://token-burner-seven.vercel.app`
-
-### First-time registration
+The published package wraps every API in this doc — claim code, register, link, and the full burn-session handshake (start → heartbeat → step events → finish). **Use it first. Do not hand-roll HTTP against endpoints you reverse-engineered out of the bundle.**
 
 ```
-POST /api/claim-codes
-→ 201 { code, expiresAt }
+npx token-burner register --claim-code <CODE> --handle <NAME> --avatar <EMOJI> --agent-label <LABEL>
+npx token-burner link     --agent-label <LABEL>                   # returning installations
+npx token-burner burn     --provider <openai|anthropic> --preset <tier-1|tier-2|tier-3>
+npx token-burner whoami
 ```
 
-```
-POST /api/agent/register
-body: { claimCode, publicHandle, avatar, agentLabel }
-→ 201 { humanId, agentInstallationId, ownerToken, handle, avatar }
-→ 409 if the claim code is invalid/expired/consumed
-```
+- Provider credentials come from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` in the shell env. Innies keys (`in_live_*`) are auto-routed through `https://api.innies.computer/v1/proxy`; no extra flag needed.
+- The CLI persists identity in `~/.config/token-burner/config.json` (see below).
+- If the human says "burn tier-1", you should be running `npx token-burner burn --provider <chosen> --preset tier-1`, not crafting manual requests.
 
-Persist the returned identity to `~/.config/token-burner/config.json` (create parent dirs if missing, `chmod 600`) using exactly this shape:
+## Config file shape
+
+Persist the returned identity to `~/.config/token-burner/config.json` (create parent dirs if missing, `chmod 600`):
 
 ```json
 {
@@ -47,6 +46,24 @@ Persist the returned identity to `~/.config/token-burner/config.json` (create pa
 
 The `ownerToken` is reusable — it is the credential for future burns and for linking more installations. Never commit this file and never send it to remote systems.
 
+## Endpoints (reference only — prefer the CLI above)
+
+Base URL: `https://token-burner-seven.vercel.app`
+
+### Claim code + registration
+
+```
+POST /api/claim-codes
+→ 201 { code, expiresAt }
+```
+
+```
+POST /api/agent/register
+body: { claimCode, publicHandle, avatar, agentLabel }
+→ 201 { humanId, agentInstallationId, ownerToken, handle, avatar }
+→ 409 if the claim code is invalid/expired/consumed
+```
+
 ### Returning installation
 
 ```
@@ -56,13 +73,33 @@ body: { ownerToken, agentLabel }
 → 401 if the owner token is invalid or revoked
 ```
 
-### Starting and running a burn
+### Burn session
 
-Later chunks of the product define these; they require the owner token and return a burn-session token used for telemetry.
+A burn is a server-authoritative session — the site tracks the target, your heartbeats, and the per-step token counts.
+
+```
+POST /api/burns/start
+body: { ownerToken, agentInstallationId, provider, model, targetTokens, presetId? }
+→ 201 { burnId, burnSessionToken, status }
+
+POST /api/burns/{burnId}/heartbeat
+body: { burnSessionToken }
+→ 200 { status }
+
+POST /api/burns/{burnId}/events
+body: { burnSessionToken, stepIndex, stepInputTokens, stepOutputTokens, totalBilledTokens, stopReason }
+→ 201
+
+POST /api/burns/{burnId}/finish
+body: { burnSessionToken, terminalStatus, totalBilledTokens, stopReason }
+→ 200
+```
+
+If you are not using the npm CLI, you are responsible for: capping step size under the remaining target, heartbeating on a schedule, cleanly calling `finish` on any exit path (including aborts), and never starting a second burn while one is active.
 
 ## Flow summary
 
-1. If `~/.config/token-burner/config.json` is missing: get a claim code from the site and call `/api/agent/register` with the handle + avatar the user gives you, plus an agent label for this installation.
-2. If the config file exists: call `/api/agent/link` with the stored `ownerToken` and a new agent label to record this installation.
+1. If `~/.config/token-burner/config.json` is missing: get a claim code from the site and call `/api/agent/register` with the handle + avatar the user gives you, plus an agent label for this installation — or simpler, `npx token-burner register …`.
+2. If the config file exists: `npx token-burner link --agent-label …` (or `POST /api/agent/link`) to record this installation.
 3. Write/update `~/.config/token-burner/config.json` in the shape shown above. Never commit it, never upload it.
-4. Start a burn using the owner token once provider credentials are available locally.
+4. Start a burn with `npx token-burner burn --provider … --preset …` once `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is available locally.

--- a/apps/site/src/app/_components/onboard-panel.tsx
+++ b/apps/site/src/app/_components/onboard-panel.tsx
@@ -13,10 +13,10 @@ type ClaimState =
   | { status: "ready"; code: string; expiresAt: string };
 
 const buildSignupPrompt = (appUrl: string, code: string): string =>
-  `read ${appUrl}/skill.md then register me on token-burner with claim code ${code}. ask me what public handle and single-emoji avatar i want — do not pick for me. save the returned identity (publicHandle, avatar, ownerToken, humanId, agentInstallationId, baseUrl) to ~/.config/token-burner/config.json with mode 0600.`;
+  `read ${appUrl}/skill.md then onboard me on token-burner using claim code ${code}. ask me what public handle and single-emoji avatar i want — do not pick for me. use the published npm cli: \`npx token-burner register --claim-code ${code} --handle <name> --avatar <emoji> --agent-label <label>\`. it writes ~/.config/token-burner/config.json for you. do not hand-roll http against endpoints from the bundle.`;
 
 const buildReturningPrompt = (appUrl: string): string =>
-  `read ${appUrl}/skill.md then link this installation to my existing token-burner identity. read the owner token from ~/.config/token-burner/config.json if present; if the file is missing, ask me to paste the owner token. then call /api/agent/link and update that same config file with the new agentInstallationId.`;
+  `read ${appUrl}/skill.md then link this installation to my existing token-burner identity. run \`npx token-burner link --agent-label <label>\` — it reads the owner token from ~/.config/token-burner/config.json. if that file is missing, ask me to paste the owner token and pass it with --owner-token. do not hand-roll http against endpoints from the bundle.`;
 
 export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element {
   const [mode, setMode] = useState<Mode>("new");

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-burner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI runtime for token-burner: claim an identity on the public site, then waste provider tokens publicly from your agent.",
   "keywords": [
     "cli",

--- a/packages/agent-cli/src/providers/anthropic.ts
+++ b/packages/agent-cli/src/providers/anthropic.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 import { providerFlagshipModels } from "@token-burner/shared";
 
+import { isInniesKey, resolveInniesProxyBaseUrl } from "./innies.js";
 import type {
   BurnStepRequest,
   BurnStepResult,
@@ -23,7 +24,10 @@ export const createAnthropicAdapter = (
     );
   }
 
-  const client = new Anthropic({ apiKey: credentials.apiKey });
+  const baseURL = isInniesKey(credentials.apiKey)
+    ? resolveInniesProxyBaseUrl("anthropic")
+    : undefined;
+  const client = new Anthropic({ apiKey: credentials.apiKey, baseURL });
 
   return {
     providerId: "anthropic",

--- a/packages/agent-cli/src/providers/innies.ts
+++ b/packages/agent-cli/src/providers/innies.ts
@@ -1,0 +1,29 @@
+import type { ProviderId } from "@token-burner/shared";
+
+const INNIES_DEFAULT_BASE_URL = "https://api.innies.computer";
+
+const inniesKeyPrefixes = ["in_live_", "in_test_"] as const;
+
+export const isInniesKey = (apiKey: string): boolean =>
+  inniesKeyPrefixes.some((prefix) => apiKey.startsWith(prefix));
+
+const trimTrailingSlash = (value: string): string =>
+  value.endsWith("/") ? value.slice(0, -1) : value;
+
+const resolveInniesRoot = (
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): string => trimTrailingSlash(env.INNIES_BASE_URL ?? INNIES_DEFAULT_BASE_URL);
+
+export const resolveInniesProxyBaseUrl = (
+  providerId: ProviderId,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): string => {
+  const root = resolveInniesRoot(env);
+  if (providerId === "openai") {
+    return `${root}/v1/proxy/v1`;
+  }
+  if (providerId === "anthropic") {
+    return `${root}/v1/proxy`;
+  }
+  throw new Error(`unknown provider ${providerId} for innies routing`);
+};

--- a/packages/agent-cli/src/providers/openai.ts
+++ b/packages/agent-cli/src/providers/openai.ts
@@ -2,6 +2,7 @@ import OpenAI from "openai";
 
 import { providerFlagshipModels } from "@token-burner/shared";
 
+import { isInniesKey, resolveInniesProxyBaseUrl } from "./innies.js";
 import type {
   BurnStepRequest,
   BurnStepResult,
@@ -23,7 +24,10 @@ export const createOpenAIAdapter = (
     );
   }
 
-  const client = new OpenAI({ apiKey: credentials.apiKey });
+  const baseURL = isInniesKey(credentials.apiKey)
+    ? resolveInniesProxyBaseUrl("openai")
+    : undefined;
+  const client = new OpenAI({ apiKey: credentials.apiKey, baseURL });
 
   return {
     providerId: "openai",

--- a/tests/unit/providers-innies.test.ts
+++ b/tests/unit/providers-innies.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isInniesKey,
+  resolveInniesProxyBaseUrl,
+} from "../../packages/agent-cli/src/providers/innies";
+
+describe("innies key detection", () => {
+  it("recognizes live and test prefixes", () => {
+    expect(isInniesKey("in_live_abcdef")).toBe(true);
+    expect(isInniesKey("in_test_abcdef")).toBe(true);
+  });
+
+  it("rejects real openai and anthropic prefixes", () => {
+    expect(isInniesKey("sk-proj-deadbeef")).toBe(false);
+    expect(isInniesKey("sk-ant-api03-xyz")).toBe(false);
+  });
+});
+
+describe("innies proxy base url", () => {
+  it("routes openai through the chat/completions-friendly prefix", () => {
+    expect(resolveInniesProxyBaseUrl("openai", {})).toBe(
+      "https://api.innies.computer/v1/proxy/v1",
+    );
+  });
+
+  it("routes anthropic so the sdk can append /v1/messages", () => {
+    expect(resolveInniesProxyBaseUrl("anthropic", {})).toBe(
+      "https://api.innies.computer/v1/proxy",
+    );
+  });
+
+  it("honors INNIES_BASE_URL override and trims trailing slash", () => {
+    expect(
+      resolveInniesProxyBaseUrl("openai", {
+        INNIES_BASE_URL: "https://innies.test/",
+      }),
+    ).toBe("https://innies.test/v1/proxy/v1");
+  });
+});


### PR DESCRIPTION
## Summary
Diagnosis from a failed new-user onboard (friend's codex agent): (1) skill.md punted on burn endpoints so the agent tried to reverse-engineer them from the next.js bundle; (2) the prompt never names the published npm cli; (3) the friend's \`OPENAI_API_KEY\` was actually an Innies \`in_live_*\` token, which would 401 against api.openai.com even if the flow had been followed.

This PR:
- Routes \`in_live_*\` / \`in_test_*\` keys through \`https://api.innies.computer/v1/proxy\` in both the OpenAI and Anthropic adapters. Works as a drop-in — the innies proxy forwards to the real upstream, so token counts still come from the official apis. Overridable via \`INNIES_BASE_URL\`.
- Skill.md now leads with the cli wrappers (\`npx token-burner register / link / burn / whoami\`) and documents the full burn-session handshake (start → heartbeat → events → finish) so agents who insist on hand-rolling have a spec.
- Onboard panel prompts tell agents to use \`npx token-burner register\` / \`link\` instead of inventing http calls.
- Cli → 0.1.2.

## Note on take-effect
The skill.md + onboard-prompt changes deploy via vercel on merge. The Innies routing lives in the cli and only reaches \`npx token-burner\` users after a follow-up \`npm publish\` of 0.1.2 from \`packages/agent-cli/\`.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint -w @token-burner/site\` clean
- [x] \`vitest run tests/unit/providers-innies.test.ts tests/unit/local-store.test.ts tests/unit/agent-cli-commands.test.ts\` → 16 passed
- [ ] After vercel deploys: \`curl .../skill.md\` contains \`npx token-burner\` and the burn-session endpoints block
- [ ] After \`npm publish\`: \`OPENAI_API_KEY=in_live_... npx token-burner burn --provider openai --preset tier-1\` hits innies instead of api.openai.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)