### PR TITLE
chore: onboard prompt step 5 — ask tier + run burn

### DIFF
--- a/apps/site/src/app/_components/onboard-panel.tsx
+++ b/apps/site/src/app/_components/onboard-panel.tsx
@@ -18,6 +18,7 @@ const buildSignupPrompt = (appUrl: string, code: string): string =>
     `2. ask me what public handle and single-emoji avatar i want — do not pick for me.`,
     `3. run: npx token-burner register --claim-code ${code} --handle <name> --avatar <emoji> --agent-label <label>`,
     `4. the cli writes ~/.config/token-burner/config.json for you. do not hand-roll http against endpoints from the bundle.`,
+    `5. ask me which tier i want to burn — tier-1 (25k billed tokens), tier-2 (250k), or tier-3 (2.5m) — and which provider (openai | anthropic). then run: npx token-burner burn --provider <provider> --preset <tier>`,
   ].join("\n");
 
 const buildReturningPrompt = (appUrl: string): string =>
@@ -26,6 +27,7 @@ const buildReturningPrompt = (appUrl: string): string =>
     `2. run: npx token-burner link --agent-label <label>`,
     `3. if ~/.config/token-burner/config.json is missing, ask me to paste the owner token and pass it with --owner-token.`,
     `4. do not hand-roll http against endpoints from the bundle.`,
+    `5. ask me which tier i want to burn — tier-1 (25k billed tokens), tier-2 (250k), or tier-3 (2.5m) — and which provider (openai | anthropic). then run: npx token-burner burn --provider <provider> --preset <tier>`,
   ].join("\n");
 
 export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element {


### PR DESCRIPTION
## Summary
Adds a 5th step to both signup + returning onboard prompts: after register/link, ask the user which tier (tier-1 25k, tier-2 250k, tier-3 2.5m) + provider (openai | anthropic), then run \`npx token-burner burn\`. Closes the flow — previously the agent would finish onboarding and wait for the user to know to say "burn tier-1".

## Test plan
- [ ] Mint code → prompt shows 5 numbered steps, last one lists the three tiers + expected token counts.
- [ ] Returning flow also shows the same step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)