### PR TITLE
feat: onboard step 5 uses --target + per-provider leaderboard totals

### DIFF
--- a/apps/site/src/app/_components/leaderboard-section.tsx
+++ b/apps/site/src/app/_components/leaderboard-section.tsx
@@ -31,7 +31,8 @@ export function LeaderboardSection({ title, leaderboard }: LeaderboardSectionPro
       </div>
       <div className="grid grid-cols-1 gap-0 border-2 border-ivory md:grid-cols-2">
         {providerValues.map((provider, providerIndex) => {
-          const entries = leaderboard[provider];
+          const entries = leaderboard.entries[provider];
+          const total = leaderboard.totals[provider];
           return (
             <div
               key={provider}
@@ -39,12 +40,17 @@ export function LeaderboardSection({ title, leaderboard }: LeaderboardSectionPro
                 providerIndex === 0 ? "md:border-r-2 md:border-ivory" : ""
               } border-b-2 border-ivory last:border-b-0 md:border-b-0`}
             >
-              <div className="flex items-baseline justify-between border-b-2 border-ivory bg-char px-5 py-3">
-                <h3 className="display text-xl font-black tracking-tight">
-                  {providerLabels[provider]}
-                </h3>
+              <div className="flex items-baseline justify-between gap-3 border-b-2 border-ivory bg-char px-5 py-3">
+                <div className="flex items-baseline gap-3">
+                  <h3 className="display text-xl font-black tracking-tight">
+                    {providerLabels[provider]}
+                  </h3>
+                  <span className="mono text-sm tabular-nums text-ember">
+                    {formatTokens(total)}
+                  </span>
+                </div>
                 <span className="mono text-[0.65rem] uppercase tracking-widest text-bone">
-                  billed tokens
+                  billed total
                 </span>
               </div>
               {entries.length === 0 ? (

--- a/apps/site/src/app/_components/onboard-panel.tsx
+++ b/apps/site/src/app/_components/onboard-panel.tsx
@@ -18,7 +18,7 @@ const buildSignupPrompt = (appUrl: string, code: string): string =>
     `2. ask me what public handle and single-emoji avatar i want — do not pick for me.`,
     `3. run: npx token-burner register --claim-code ${code} --handle <name> --avatar <emoji> --agent-label <label>`,
     `4. the cli writes ~/.config/token-burner/config.json for you. do not hand-roll http against endpoints from the bundle.`,
-    `5. ask me which tier i want to burn — tier-1 (25k billed tokens), tier-2 (250k), or tier-3 (2.5m) — and which provider (openai | anthropic). then run: npx token-burner burn --provider <provider> --preset <tier>`,
+    `5. ask me how many tokens to burn (examples: 25k, 250k, 2.5m). if both OPENAI_API_KEY and ANTHROPIC_API_KEY are set, ask which provider too; otherwise use whichever is set. then run: npx token-burner burn --provider <openai|anthropic> --target <n>`,
   ].join("\n");
 
 const buildReturningPrompt = (appUrl: string): string =>
@@ -27,7 +27,7 @@ const buildReturningPrompt = (appUrl: string): string =>
     `2. run: npx token-burner link --agent-label <label>`,
     `3. if ~/.config/token-burner/config.json is missing, ask me to paste the owner token and pass it with --owner-token.`,
     `4. do not hand-roll http against endpoints from the bundle.`,
-    `5. ask me which tier i want to burn — tier-1 (25k billed tokens), tier-2 (250k), or tier-3 (2.5m) — and which provider (openai | anthropic). then run: npx token-burner burn --provider <provider> --preset <tier>`,
+    `5. ask me how many tokens to burn (examples: 25k, 250k, 2.5m). if both OPENAI_API_KEY and ANTHROPIC_API_KEY are set, ask which provider too; otherwise use whichever is set. then run: npx token-burner burn --provider <openai|anthropic> --target <n>`,
   ].join("\n");
 
 export function OnboardPanel({ appUrl }: { appUrl: string }): React.JSX.Element {

--- a/apps/site/src/lib/db/queries.ts
+++ b/apps/site/src/lib/db/queries.ts
@@ -74,7 +74,10 @@ export type LeaderboardEntry = Omit<LeaderboardRow, "latestBurnCreatedAt"> & {
   rank: number;
 };
 
-export type ProviderSplitLeaderboard = Record<ProviderId, LeaderboardEntry[]>;
+export type ProviderSplitLeaderboard = {
+  entries: Record<ProviderId, LeaderboardEntry[]>;
+  totals: Record<ProviderId, number>;
+};
 
 export type LiveBurnFeedEntry = BurnRecordRow & {
   lastHeartbeatAt: Date | null;
@@ -138,12 +141,18 @@ const mapLeaderboardRows = (
   rows: LeaderboardRow[],
   limit: number,
 ): ProviderSplitLeaderboard => {
-  const splitResults = createEmptyProviderRecord<LeaderboardEntry[]>(() => []);
+  const entries = createEmptyProviderRecord<LeaderboardEntry[]>(() => []);
+  const totals = createEmptyProviderRecord<number>(() => 0);
 
   for (const provider of providerValues) {
     const providerRows = rows.filter((row) => row.provider === provider);
 
-    splitResults[provider] = providerRows.slice(0, limit).map((row, index) => ({
+    totals[provider] = providerRows.reduce(
+      (sum, row) => sum + normalizeNumericValue(row.totalBilledTokens),
+      0,
+    );
+
+    entries[provider] = providerRows.slice(0, limit).map((row, index) => ({
       humanId: row.humanId,
       handle: row.handle,
       avatarUrl: row.avatarUrl,
@@ -153,7 +162,7 @@ const mapLeaderboardRows = (
     }));
   }
 
-  return splitResults;
+  return { entries, totals };
 };
 
 const getProviderLeaderboard = async ({

--- a/tests/integration/db-queries.test.ts
+++ b/tests/integration/db-queries.test.ts
@@ -301,7 +301,7 @@ describe("database query layer", () => {
       database,
     });
 
-    expect(daily.openai).toMatchObject([
+    expect(daily.entries.openai).toMatchObject([
       {
         humanId: alice.humanId,
         handle: "Alice",
@@ -310,7 +310,7 @@ describe("database query layer", () => {
         rank: 1,
       },
     ]);
-    expect(daily.anthropic).toMatchObject([
+    expect(daily.entries.anthropic).toMatchObject([
       {
         humanId: chloe.humanId,
         handle: "Chloe",
@@ -319,42 +319,43 @@ describe("database query layer", () => {
         rank: 1,
       },
     ]);
+    expect(daily.totals).toEqual({ openai: 600, anthropic: 900 });
 
-    expect(weekly.openai.map((entry) => entry.handle)).toEqual(["Bob", "Alice"]);
-    expect(weekly.openai.map((entry) => entry.totalBilledTokens)).toEqual([
-      800,
-      600,
+    expect(weekly.entries.openai.map((entry) => entry.handle)).toEqual([
+      "Bob",
+      "Alice",
     ]);
-    expect(weekly.anthropic.map((entry) => entry.handle)).toEqual([
+    expect(weekly.entries.openai.map((entry) => entry.totalBilledTokens)).toEqual(
+      [800, 600],
+    );
+    expect(weekly.entries.anthropic.map((entry) => entry.handle)).toEqual([
       "Chloe",
       "Alice",
     ]);
-    expect(weekly.anthropic.map((entry) => entry.totalBilledTokens)).toEqual([
-      900,
-      500,
-    ]);
+    expect(
+      weekly.entries.anthropic.map((entry) => entry.totalBilledTokens),
+    ).toEqual([900, 500]);
+    expect(weekly.totals).toEqual({ openai: 1_400, anthropic: 1_400 });
 
-    expect(allTime.openai.map((entry) => entry.handle)).toEqual([
+    expect(allTime.entries.openai.map((entry) => entry.handle)).toEqual([
       "Chloe",
       "Bob",
       "Alice",
     ]);
-    expect(allTime.openai.map((entry) => entry.totalBilledTokens)).toEqual([
-      1_200,
-      800,
-      600,
-    ]);
-    expect(allTime.anthropic.map((entry) => entry.handle)).toEqual([
+    expect(
+      allTime.entries.openai.map((entry) => entry.totalBilledTokens),
+    ).toEqual([1_200, 800, 600]);
+    expect(allTime.entries.anthropic.map((entry) => entry.handle)).toEqual([
       "Chloe",
       "Alice",
     ]);
-    expect(allTime.anthropic.map((entry) => entry.totalBilledTokens)).toEqual([
-      900,
-      500,
-    ]);
+    expect(
+      allTime.entries.anthropic.map((entry) => entry.totalBilledTokens),
+    ).toEqual([900, 500]);
+    expect(allTime.totals).toEqual({ openai: 2_600, anthropic: 1_400 });
 
-    expect(daily.openai[0]).not.toHaveProperty("burnId");
-    expect(daily.openai[0]).not.toHaveProperty("billedTokensConsumed");
+    expect(daily.entries.openai[0]).not.toHaveProperty("burnId");
+    expect(daily.entries.openai[0]).not.toHaveProperty("billedTokensConsumed");
   });
 
   it("aggregates same-human burns into one ranked leaderboard row per provider", async () => {
@@ -417,7 +418,7 @@ describe("database query layer", () => {
       database,
     });
 
-    expect(daily.openai).toMatchObject([
+    expect(daily.entries.openai).toMatchObject([
       {
         humanId: alice.humanId,
         handle: "Alice",
@@ -435,21 +436,21 @@ describe("database query layer", () => {
         rank: 2,
       },
     ]);
-    expect(daily.openai).toHaveLength(2);
-    expect(daily.openai[0]).not.toHaveProperty("burnId");
-    expect(daily.openai[0]).not.toHaveProperty("billedTokensConsumed");
+    expect(daily.entries.openai).toHaveLength(2);
+    expect(daily.entries.openai[0]).not.toHaveProperty("burnId");
+    expect(daily.entries.openai[0]).not.toHaveProperty("billedTokensConsumed");
+    expect(daily.totals).toEqual({ openai: 1_450, anthropic: 950 });
 
-    expect(weekly.openai.map((entry) => entry.totalBilledTokens)).toEqual([
-      1_050,
-      700,
-    ]);
-    expect(weekly.openai.map((entry) => entry.rank)).toEqual([1, 2]);
+    expect(weekly.entries.openai.map((entry) => entry.totalBilledTokens)).toEqual(
+      [1_050, 700],
+    );
+    expect(weekly.entries.openai.map((entry) => entry.rank)).toEqual([1, 2]);
+    expect(weekly.totals).toEqual({ openai: 1_750, anthropic: 950 });
 
-    expect(allTime.openai.map((entry) => entry.totalBilledTokens)).toEqual([
-      1_050,
-      700,
-    ]);
-    expect(allTime.anthropic).toMatchObject([
+    expect(
+      allTime.entries.openai.map((entry) => entry.totalBilledTokens),
+    ).toEqual([1_050, 700]);
+    expect(allTime.entries.anthropic).toMatchObject([
       {
         humanId: bob.humanId,
         handle: "Bob",
@@ -458,6 +459,7 @@ describe("database query layer", () => {
         rank: 1,
       },
     ]);
+    expect(allTime.totals).toEqual({ openai: 1_750, anthropic: 950 });
   });
 
   it("returns only active burns in the live feed", async () => {


### PR DESCRIPTION
## Summary
Two changes from the same review pass:

1. **Onboard prompt step 5** — asks for an arbitrary token count (examples: 25k, 250k, 2.5m) and only asks for a provider when both OPENAI/ANTHROPIC keys are set. Uses \`npx token-burner burn --target <n>\` so any amount works, not just the preset ids. Tiers become examples, not an enum.
2. **Per-provider totals on leaderboards** — every section (today, this week, all time) now shows a total-burned number next to each provider header. Sums *all* terminal burns in the window, not just the top 10 visible.

Leaderboard shape changed: \`ProviderSplitLeaderboard\` is now \`{ entries, totals }\` — sole consumers are the site\'s page + the integration tests; both updated here.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint -w @token-burner/site\` clean
- [x] \`npm test\` → 67/67 green (db-queries adds totals assertions)
- [ ] After deploy: today/this-week/all-time sections show the two totals in ember next to OPENAI / ANTHROPIC
- [ ] Mint a new claim code → step 5 mentions \`--target <n>\` and lists tiers as examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)