### PR TITLE
chore: agent picks avatar emoji, stops asking human

### DIFF
--- a/apps/site/public/skill.md
+++ b/apps/site/public/skill.md
@@ -99,7 +99,7 @@ If you are not using the npm CLI, you are responsible for: capping step size und
 
 ## Flow summary
 
-1. If `~/.config/token-burner/config.json` is missing: get a claim code from the site and call `/api/agent/register` with the handle + avatar the user gives you, plus an agent label for this installation — or simpler, `npx token-burner register …`.
+1. If `~/.config/token-burner/config.json` is missing: get a claim code from the site and call `/api/agent/register` with a handle the user gives you (ask them — never pick), an avatar you pick yourself (one emoji at random from 🔥 🌋 ☄️ 💥 🧨 🎆 🎇 💣 ⚡ 🕯️ — do not ask the user, they can't type emoji into a cli prompt), and an agent label for this installation — or simpler, `npx token-burner register …`.
 2. If the config file exists: `npx token-burner link --agent-label …` (or `POST /api/agent/link`) to record this installation.
 3. Write/update `~/.config/token-burner/config.json` in the shape shown above. Never commit it, never upload it.
 4. Start a burn with `npx token-burner burn --provider … --preset …` once `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is available locally.

--- a/apps/site/src/app/_components/onboard-panel.tsx
+++ b/apps/site/src/app/_components/onboard-panel.tsx
@@ -15,8 +15,8 @@ type ClaimState =
 const buildSignupPrompt = (appUrl: string, code: string): string =>
   [
     `1. fetch ${appUrl}/skill.md and follow that spec.`,
-    `2. ask me what public handle and single-emoji avatar i want — do not pick for me.`,
-    `3. run: npx token-burner register --claim-code ${code} --handle <name> --avatar <emoji> --agent-label <label>`,
+    `2. ask me what public handle i want — do not pick for me. pick the avatar yourself: one emoji at random from 🔥 🌋 ☄️ 💥 🧨 🎆 🎇 💣 ⚡ 🕯️ (do not ask me — humans can't type emoji into cli agents).`,
+    `3. run: npx token-burner register --claim-code ${code} --handle <name> --avatar <emoji-you-picked> --agent-label <label>`,
     `4. the cli writes ~/.config/token-burner/config.json for you. do not hand-roll http against endpoints from the bundle.`,
     `5. ask me how many tokens to burn (examples: 25k, 250k, 2.5m). if both OPENAI_API_KEY and ANTHROPIC_API_KEY are set, ask which provider too; otherwise use whichever is set. then run: npx token-burner burn --provider <openai|anthropic> --target <n>`,
   ].join("\n");


### PR DESCRIPTION
## Summary
Asking the user for a single-emoji avatar inside a cli-agent prompt is a dead end — most cli inputs don't accept emoji (keyboard can't type them, paste is awkward). The agent now picks randomly from a curated on-brand set (🔥 🌋 ☄️ 💥 🧨 🎆 🎇 💣 ⚡ 🕯️). Handle is still user-supplied.

Mirrored in skill.md so agents reading the spec directly see the same rule.

## Test plan
- [ ] Mint a new claim code → step 2 says "ask me what public handle i want" + "pick the avatar yourself" from the curated list.
- [ ] curl /skill.md → flow summary instructs agent to pick an avatar, not ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)