### PR TITLE
feat(cli): accept k/m/b shorthand for --target

### DIFF
--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-burner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "CLI runtime for token-burner: claim an identity on the public site, then waste provider tokens publicly from your agent.",
   "keywords": [
     "cli",

--- a/packages/agent-cli/src/commands/burn.ts
+++ b/packages/agent-cli/src/commands/burn.ts
@@ -50,12 +50,33 @@ const defaultAdapterFactory = (
 
 const parseProvider = (value: string): ProviderId => providerSchema.parse(value);
 
-const parsePositiveInt = (value: string, label: string): number => {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new CliArgsError(`--${label} must be a positive integer`);
+const tokenSuffixMultipliers: Record<string, number> = {
+  k: 1_000,
+  m: 1_000_000,
+  b: 1_000_000_000,
+};
+
+export const parseTokenTarget = (value: string): number => {
+  const trimmed = value.trim().toLowerCase().replace(/[_,]/g, "");
+
+  const suffixMatch = trimmed.match(/^(\d+(?:\.\d+)?)([kmb])$/);
+  if (suffixMatch) {
+    const base = Number(suffixMatch[1]);
+    const multiplier = tokenSuffixMultipliers[suffixMatch[2]];
+    const result = Math.round(base * multiplier);
+    if (Number.isInteger(result) && result > 0) {
+      return result;
+    }
   }
-  return parsed;
+
+  const plain = Number(trimmed);
+  if (Number.isInteger(plain) && plain > 0) {
+    return plain;
+  }
+
+  throw new CliArgsError(
+    "--target must be a positive integer or shorthand like 5k, 250k, 2.5m, 1b",
+  );
 };
 
 export const formatBurnUsage = (): string =>
@@ -122,10 +143,7 @@ export const runBurnCommand = async ({
       targetTokens = getBurnPreset(parsedPresetId).targetTokens;
     } else {
       presetId = null;
-      targetTokens = parsePositiveInt(
-        requireFlag(flags, "target"),
-        "target",
-      );
+      targetTokens = parseTokenTarget(requireFlag(flags, "target"));
     }
     baseUrlOverride = flags["base-url"];
   } catch (error) {

--- a/tests/unit/parse-token-target.test.ts
+++ b/tests/unit/parse-token-target.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTokenTarget } from "../../packages/agent-cli/src/commands/burn";
+import { CliArgsError } from "../../packages/agent-cli/src/args";
+
+describe("parseTokenTarget", () => {
+  it("parses plain integers", () => {
+    expect(parseTokenTarget("5000")).toBe(5_000);
+    expect(parseTokenTarget("250000")).toBe(250_000);
+    expect(parseTokenTarget("1")).toBe(1);
+  });
+
+  it("parses k/m/b suffix shorthand", () => {
+    expect(parseTokenTarget("5k")).toBe(5_000);
+    expect(parseTokenTarget("250k")).toBe(250_000);
+    expect(parseTokenTarget("2.5m")).toBe(2_500_000);
+    expect(parseTokenTarget("1m")).toBe(1_000_000);
+    expect(parseTokenTarget("1b")).toBe(1_000_000_000);
+  });
+
+  it("is case-insensitive and tolerates underscores or commas", () => {
+    expect(parseTokenTarget("5K")).toBe(5_000);
+    expect(parseTokenTarget("2.5M")).toBe(2_500_000);
+    expect(parseTokenTarget("250_000")).toBe(250_000);
+    expect(parseTokenTarget("1,000,000")).toBe(1_000_000);
+  });
+
+  it("rejects zero, negatives, fractions of plain integers, and garbage", () => {
+    expect(() => parseTokenTarget("0")).toThrow(CliArgsError);
+    expect(() => parseTokenTarget("-5")).toThrow(CliArgsError);
+    expect(() => parseTokenTarget("5.5")).toThrow(CliArgsError);
+    expect(() => parseTokenTarget("nope")).toThrow(CliArgsError);
+    expect(() => parseTokenTarget("0k")).toThrow(CliArgsError);
+    expect(() => parseTokenTarget("5x")).toThrow(CliArgsError);
+  });
+});


### PR DESCRIPTION
## Summary
\`--target 5k\` / \`250k\` / \`2.5m\` / \`1b\` now work — previously only plain integers were accepted. The codex test transcript fired \`--target 5k\`, got \`must be a positive integer\`, and had to retry with \`5000\`. The onboard prompt also lists examples in shorthand, so this aligns the cli to what we tell agents to type.

Also tolerates underscores and commas (\`250_000\`, \`1,000,000\`).

Note: this only addresses the ergonomic gap. The codex burn that hit a 403 from Innies/upstream OpenAI is unrelated — fixed-target value or not, the upstream call would still 403.

## Test plan
- [x] \`vitest run tests/unit/parse-token-target.test.ts\` → 4 cases (plain int, suffix, separators, error cases)
- [x] Existing \`agent-cli-burn\` + \`agent-cli-commands\` suites still green (12 + 8)
- [ ] After \`npm publish\`: \`npx token-burner burn --provider openai --target 5k\` proceeds to the burn step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)