### PR TITLE
chore: leaderboards exclude zero-billed burns

### DIFF
--- a/apps/site/src/lib/db/queries.ts
+++ b/apps/site/src/lib/db/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, sql } from "drizzle-orm";
 import { type NodePgDatabase } from "drizzle-orm/node-postgres";
 
 import {
@@ -173,7 +173,10 @@ const getProviderLeaderboard = async ({
   windowStart?: Date;
 }): Promise<ProviderSplitLeaderboard> => {
   const queryDatabase = await resolveDatabase(database);
-  const conditions = [inArray(burns.status, terminalBurnStatusValues)];
+  const conditions = [
+    inArray(burns.status, terminalBurnStatusValues),
+    gt(burns.billedTokensConsumed, 0),
+  ];
 
   if (windowStart) {
     conditions.push(gte(burns.createdAt, windowStart));


### PR DESCRIPTION
## Summary
A failed-immediately burn (e.g., upstream provider 403 with no steps consumed) creates a \`burns\` row with \`billed_tokens_consumed = 0\` and \`status = failed\`. The leaderboard query was including those terminal-status rows, which surfaced 0-token burners on the board (one example: \`idiot\` from a recent codex test transcript).

Add \`gt(burns.billedTokensConsumed, 0)\` to the conditions so leaderboards only count burns that actually burned. Live-feed (active burns) untouched.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm test -- tests/integration/db-queries.test.ts\` → 6 pass (existing fixtures all have > 0 tokens, so no test changes needed)
- [ ] After deploy: \`idiot\` no longer appears on today/this-week/all-time. Totals unchanged (0 doesn't affect the sum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)