### PR TITLE
feat(cli): --api-key override + louder missing-creds error

### DIFF
--- a/apps/site/public/skill.md
+++ b/apps/site/public/skill.md
@@ -14,6 +14,17 @@ The human has a token-burner claim code (or an owner token, for returning humans
 - One active burn per human at a time.
 - If this CLI session ends, the burn ends.
 
+## Provider credentials gotcha
+
+The cli reads `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the shell env. **Most cli-agent runtimes (Claude Code, Codex, Cursor, etc.) do NOT pass their own provider auth to spawned subprocesses** — so even if the agent itself is currently talking to Anthropic, `ANTHROPIC_API_KEY` may be empty inside `Bash` / `npx`.
+
+If `npx token-burner burn` errors with `no local <provider> credentials found`:
+
+1. Ask the user whether they have an `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` available.
+2. If they paste a key into chat, pass it through with `--api-key` instead of relying on env:
+   `npx token-burner burn --provider <p> --target <n> --api-key <KEY>`
+3. Never log, persist, or upload the key. Use it once on the cli flag and forget it.
+
 ## Recommended path: the `token-burner` npm CLI
 
 The published package wraps every API in this doc — claim code, register, link, and the full burn-session handshake (start → heartbeat → step events → finish). **Use it first. Do not hand-roll HTTP against endpoints you reverse-engineered out of the bundle.**

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-burner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CLI runtime for token-burner: claim an identity on the public site, then waste provider tokens publicly from your agent.",
   "keywords": [
     "cli",

--- a/packages/agent-cli/src/commands/burn.ts
+++ b/packages/agent-cli/src/commands/burn.ts
@@ -80,7 +80,7 @@ export const parseTokenTarget = (value: string): number => {
 };
 
 export const formatBurnUsage = (): string =>
-  `token-burner burn --provider <${providerValues.join("|")}> (--target N | --preset ${presetIdValues.join("|")}) [--base-url URL]`;
+  `token-burner burn --provider <${providerValues.join("|")}> (--target N | --preset ${presetIdValues.join("|")}) [--api-key KEY] [--base-url URL]`;
 
 export const formatBurnHelp = (): string => {
   const presetLines = burnPresets.map(
@@ -98,8 +98,11 @@ export const formatBurnHelp = (): string => {
     "",
     "Options:",
     `  --provider <${providerValues.join("|")}>`,
-    "  --target N",
+    "  --target N            (accepts shorthand: 5k, 250k, 2.5m, 1b)",
     `  --preset <${presetIdValues.join("|")}>`,
+    "  --api-key KEY         (overrides $OPENAI_API_KEY / $ANTHROPIC_API_KEY,",
+    "                         useful when launching from a cli agent that hides",
+    "                         its own provider auth from spawned subprocesses)",
     "  --base-url URL",
     "",
     "Preset tiers:",
@@ -127,6 +130,7 @@ export const runBurnCommand = async ({
   let targetTokens: number;
   let presetId: PresetId | null;
   let baseUrlOverride: string | undefined;
+  let apiKeyOverride: string | undefined;
   try {
     const { flags } = parseArgs(args);
     provider = parseProvider(requireFlag(flags, "provider"));
@@ -146,6 +150,7 @@ export const runBurnCommand = async ({
       targetTokens = parseTokenTarget(requireFlag(flags, "target"));
     }
     baseUrlOverride = flags["base-url"];
+    apiKeyOverride = flags["api-key"];
   } catch (error) {
     if (error instanceof CliArgsError) {
       stderr.write(`${error.message}\n`);
@@ -167,7 +172,9 @@ export const runBurnCommand = async ({
 
   let adapter: ProviderAdapter;
   try {
-    const credentials = credentialsResolver(provider);
+    const credentials = credentialsResolver(provider, process.env, {
+      apiKeyOverride,
+    });
     adapter = adapterFactory(credentials);
   } catch (error) {
     if (error instanceof ProviderCredentialsMissingError) {

--- a/packages/agent-cli/src/providers/resolve-credentials.ts
+++ b/packages/agent-cli/src/providers/resolve-credentials.ts
@@ -12,10 +12,19 @@ const envKeysByProvider: Record<ProviderId, readonly string[]> = {
   anthropic: ["ANTHROPIC_API_KEY"],
 };
 
+export type ResolveProviderCredentialsOptions = {
+  apiKeyOverride?: string;
+};
+
 export const resolveProviderCredentials = (
   providerId: ProviderId,
   env: EnvLike = process.env,
+  { apiKeyOverride }: ResolveProviderCredentialsOptions = {},
 ): ProviderCredentials => {
+  if (apiKeyOverride && apiKeyOverride.trim().length > 0) {
+    return { providerId, apiKey: apiKeyOverride.trim() };
+  }
+
   const candidates = envKeysByProvider[providerId];
   for (const key of candidates) {
     const value = env[key];

--- a/packages/agent-cli/src/providers/types.ts
+++ b/packages/agent-cli/src/providers/types.ts
@@ -24,8 +24,20 @@ export type ProviderCredentials = {
 
 export class ProviderCredentialsMissingError extends Error {
   constructor(providerId: ProviderId) {
+    const envVar =
+      providerId === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
     super(
-      `no local ${providerId} credentials found. token-burner only uses official provider credentials from your environment.`,
+      [
+        `no local ${providerId} credentials found.`,
+        `token-burner reads ${envVar} from your shell environment.`,
+        ``,
+        `if you launched this from a cli agent (claude code, codex, cursor, etc.):`,
+        `most agents do NOT pass their own provider auth to spawned subprocesses,`,
+        `so ${envVar} can be empty inside Bash/npx even while the agent is talking`,
+        `to ${providerId}. either:`,
+        `  (a) set ${envVar} in your shell BEFORE launching the agent, then restart it, or`,
+        `  (b) pass the key explicitly: token-burner burn --api-key <KEY> ...`,
+      ].join("\n"),
     );
     this.name = "ProviderCredentialsMissingError";
   }

--- a/tests/unit/agent-cli-burn.test.ts
+++ b/tests/unit/agent-cli-burn.test.ts
@@ -92,6 +92,24 @@ describe("resolveProviderCredentials", () => {
       resolveProviderCredentials("openai", { OPENAI_API_KEY: "   " }),
     ).toThrow(ProviderCredentialsMissingError);
   });
+
+  it("uses apiKeyOverride when env is empty (cli-agent subprocess case)", () => {
+    const result = resolveProviderCredentials(
+      "anthropic",
+      {},
+      { apiKeyOverride: "sk-ant-explicit" },
+    );
+    expect(result.apiKey).toBe("sk-ant-explicit");
+  });
+
+  it("apiKeyOverride wins over env when both are present", () => {
+    const result = resolveProviderCredentials(
+      "openai",
+      { OPENAI_API_KEY: "sk-from-env" },
+      { apiKeyOverride: "sk-from-flag" },
+    );
+    expect(result.apiKey).toBe("sk-from-flag");
+  });
 });
 
 describe("runBurnCommand", () => {
@@ -197,7 +215,7 @@ describe("runBurnCommand", () => {
     const stderr = streams.collected().stderr;
     expect(stderr).toContain("missing required flag");
     expect(stderr).toContain(
-      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--base-url URL]",
+      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--api-key KEY] [--base-url URL]",
     );
   });
 

--- a/tests/unit/agent-cli-commands.test.ts
+++ b/tests/unit/agent-cli-commands.test.ts
@@ -320,7 +320,7 @@ describe("agent cli top-level help", () => {
 
     expect(exitCode).toBe(0);
     expect(writes.stdout()).toContain(
-      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--base-url URL]",
+      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--api-key KEY] [--base-url URL]",
     );
     expect(writes.stdout()).toContain("Use exactly one of --target or --preset.");
     expect(writes.stdout()).toContain("tier-1 Amuse-Bouche");


### PR DESCRIPTION
## Summary
CLI agents sandbox their own auth away from subprocesses, so \`ANTHROPIC_API_KEY\` is often empty inside \`npx token-burner\` even when the agent is an Anthropic client. Three fixes:

1. \`burn\` now accepts \`--api-key <KEY>\` as an override over \`\$OPENAI_API_KEY\` / \`\$ANTHROPIC_API_KEY\`.
2. \`ProviderCredentialsMissingError\` is now a multi-line message that names the cli-agent subprocess gotcha and lists the two escape hatches.
3. skill.md gains a "Provider credentials gotcha" section so agents reading the spec know to ask the user for a key and forward it via the flag.

CLI → 0.1.4.

## Test plan
- [x] \`vitest\` → 73/73 green (two usage-string assertions updated, two new resolveProviderCredentials cases for override precedence)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint -w @token-burner/site\` clean
- [ ] After \`npm publish\`: \`ANTHROPIC_API_KEY= npx token-burner burn --provider anthropic --target 5k --api-key sk-ant-...\` starts a burn.
- [ ] With no key anywhere: error text mentions \`--api-key\` and the cli-agent subprocess case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)