### PR TITLE
feat: cli hardening — model fallback, safer register, key validation, EACCES, faster stale sweep

### DIFF
--- a/apps/site/public/skill.md
+++ b/apps/site/public/skill.md
@@ -39,6 +39,8 @@ npx token-burner whoami
 - Provider credentials come from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` in the shell env. Innies keys (`in_live_*`) are auto-routed through `https://api.innies.computer/v1/proxy`; no extra flag needed.
 - The CLI persists identity in `~/.config/token-burner/config.json` (see below).
 - If the human says "burn tier-1", you should be running `npx token-burner burn --provider <chosen> --preset tier-1`, not crafting manual requests.
+- **If a config already exists**, do NOT re-run `register` — the cli will refuse and tell you to run `link --agent-label <label>` instead. Re-registering only with the human's explicit permission, by passing `--overwrite`.
+- The cli auto-probes a per-provider model fallback chain (`gpt-5.4 → gpt-5 → gpt-4o → gpt-4o-mini`, `claude-opus-4-7 → claude-sonnet-4-6 → claude-haiku-4-5`). If you want to pin a specific model (or all fallbacks failed), pass `--model <id>`.
 
 ## Config file shape
 

--- a/apps/site/src/lib/server/housekeeping.ts
+++ b/apps/site/src/lib/server/housekeeping.ts
@@ -29,7 +29,10 @@ type ActiveBurnRecord = {
 };
 
 const activeBurnStatuses = ["queued", "running", "stopping"] as const;
-const staleBurnTimeoutMilliseconds = 5 * 60 * 1000;
+// 60s — short enough that a crashed/killed cli only locks a human out for
+// roughly one minute before they can start a new burn (the next start call
+// sweeps the stale row before checking the active-burn invariant).
+const staleBurnTimeoutMilliseconds = 60 * 1000;
 
 const activeBurnSelection = {
   id: schema.burns.id,

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-burner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI runtime for token-burner: claim an identity on the public site, then waste provider tokens publicly from your agent.",
   "keywords": [
     "cli",

--- a/packages/agent-cli/src/commands/burn.ts
+++ b/packages/agent-cli/src/commands/burn.ts
@@ -15,7 +15,16 @@ import { loadLocalConfig } from "../config/local-store.js";
 import { defaultBaseUrl } from "../config/defaults.js";
 import { createAnthropicAdapter } from "../providers/anthropic.js";
 import { createOpenAIAdapter } from "../providers/openai.js";
+import {
+  ProviderKeyFormatError,
+  validateProviderKeyFormat,
+} from "../providers/key-format.js";
 import { resolveProviderCredentials } from "../providers/resolve-credentials.js";
+import {
+  NoAvailableModelError,
+  selectAvailableModel,
+  type AdapterFactory,
+} from "../providers/select-model.js";
 import {
   ProviderCredentialsMissingError,
   type ProviderAdapter,
@@ -29,19 +38,20 @@ export type BurnCommandOptions = {
   io?: Partial<CommandIo>;
   fetchImpl?: FetchLike;
   homeDir?: string;
-  adapterFactory?: (credentials: ProviderCredentials) => ProviderAdapter;
+  adapterFactory?: AdapterFactory;
   credentialsResolver?: typeof resolveProviderCredentials;
   disableParentWatch?: boolean;
 };
 
-const defaultAdapterFactory = (
+const defaultAdapterFactory: AdapterFactory = (
   credentials: ProviderCredentials,
+  model: string,
 ): ProviderAdapter => {
   if (credentials.providerId === "anthropic") {
-    return createAnthropicAdapter(credentials);
+    return createAnthropicAdapter(credentials, model);
   }
   if (credentials.providerId === "openai") {
-    return createOpenAIAdapter(credentials);
+    return createOpenAIAdapter(credentials, model);
   }
   throw new Error(
     `provider ${credentials.providerId} is not wired in this build.`,
@@ -80,7 +90,7 @@ export const parseTokenTarget = (value: string): number => {
 };
 
 export const formatBurnUsage = (): string =>
-  `token-burner burn --provider <${providerValues.join("|")}> (--target N | --preset ${presetIdValues.join("|")}) [--api-key KEY] [--base-url URL]`;
+  `token-burner burn --provider <${providerValues.join("|")}> (--target N | --preset ${presetIdValues.join("|")}) [--model ID] [--api-key KEY] [--base-url URL]`;
 
 export const formatBurnHelp = (): string => {
   const presetLines = burnPresets.map(
@@ -100,6 +110,9 @@ export const formatBurnHelp = (): string => {
     `  --provider <${providerValues.join("|")}>`,
     "  --target N            (accepts shorthand: 5k, 250k, 2.5m, 1b)",
     `  --preset <${presetIdValues.join("|")}>`,
+    "  --model ID            (override the model. without this, the cli probes",
+    "                         a per-provider fallback chain and uses the first",
+    "                         model your account can actually call)",
     "  --api-key KEY         (overrides $OPENAI_API_KEY / $ANTHROPIC_API_KEY,",
     "                         useful when launching from a cli agent that hides",
     "                         its own provider auth from spawned subprocesses)",
@@ -131,6 +144,7 @@ export const runBurnCommand = async ({
   let presetId: PresetId | null;
   let baseUrlOverride: string | undefined;
   let apiKeyOverride: string | undefined;
+  let modelOverride: string | undefined;
   try {
     const { flags } = parseArgs(args);
     provider = parseProvider(requireFlag(flags, "provider"));
@@ -151,6 +165,7 @@ export const runBurnCommand = async ({
     }
     baseUrlOverride = flags["base-url"];
     apiKeyOverride = flags["api-key"];
+    modelOverride = flags.model;
   } catch (error) {
     if (error instanceof CliArgsError) {
       stderr.write(`${error.message}\n`);
@@ -175,9 +190,19 @@ export const runBurnCommand = async ({
     const credentials = credentialsResolver(provider, process.env, {
       apiKeyOverride,
     });
-    adapter = adapterFactory(credentials);
+    validateProviderKeyFormat(credentials.providerId, credentials.apiKey);
+    const selectedModel = await selectAvailableModel({
+      credentials,
+      requestedModel: modelOverride,
+      adapterFactory,
+    });
+    adapter = adapterFactory(credentials, selectedModel);
   } catch (error) {
-    if (error instanceof ProviderCredentialsMissingError) {
+    if (
+      error instanceof ProviderCredentialsMissingError ||
+      error instanceof ProviderKeyFormatError ||
+      error instanceof NoAvailableModelError
+    ) {
       stderr.write(`${error.message}\n`);
       return 1;
     }

--- a/packages/agent-cli/src/commands/link.ts
+++ b/packages/agent-cli/src/commands/link.ts
@@ -1,12 +1,21 @@
 import { CliArgsError, parseArgs, requireFlag } from "../args.js";
 import { ApiError, linkAgent, type FetchLike } from "../api/client.js";
 import {
+  getLocalConfigPath,
   loadLocalConfig,
   saveLocalConfig,
   type LocalConfig,
 } from "../config/local-store.js";
 import { defaultBaseUrl } from "../config/defaults.js";
 import type { CommandIo } from "./register.js";
+
+const isWriteAccessError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return code === "EACCES" || code === "EROFS" || code === "EPERM";
+};
 
 export type LinkCommandOptions = {
   args: string[];
@@ -68,7 +77,22 @@ export const runLinkCommand = async ({
       publicHandle: response.handle,
       avatar: response.avatar,
     };
-    await saveLocalConfig(nextConfig, { homeDir });
+    try {
+      await saveLocalConfig(nextConfig, { homeDir });
+    } catch (writeError) {
+      if (isWriteAccessError(writeError)) {
+        const path = getLocalConfigPath({ homeDir });
+        stderr.write(
+          `cannot write to ${path} (permission denied / read-only filesystem).\n`,
+        );
+        stderr.write(
+          `if HOME is sandboxed, point the cli at a writable directory:\n`,
+        );
+        stderr.write(`  HOME=$(mktemp -d) npx token-burner ...\n`);
+        return 1;
+      }
+      throw writeError;
+    }
 
     stdout.write(
       `linked installation ${response.agentInstallationId} to ${response.handle} ${response.avatar}\n`,

--- a/packages/agent-cli/src/commands/register.ts
+++ b/packages/agent-cli/src/commands/register.ts
@@ -1,6 +1,8 @@
 import { CliArgsError, parseArgs, requireFlag } from "../args.js";
 import { ApiError, registerAgent, type FetchLike } from "../api/client.js";
 import {
+  getLocalConfigPath,
+  loadLocalConfig,
   saveLocalConfig,
   type LocalConfig,
 } from "../config/local-store.js";
@@ -18,6 +20,38 @@ export type RegisterCommandOptions = {
   homeDir?: string;
 };
 
+const isWriteAccessError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return code === "EACCES" || code === "EROFS" || code === "EPERM";
+};
+
+const writeConfigOrReportPermission = async (
+  config: LocalConfig,
+  homeDir: string | undefined,
+  stderr: NodeJS.WritableStream,
+): Promise<boolean> => {
+  try {
+    await saveLocalConfig(config, { homeDir });
+    return true;
+  } catch (error) {
+    if (isWriteAccessError(error)) {
+      const path = getLocalConfigPath({ homeDir });
+      stderr.write(
+        `cannot write to ${path} (permission denied / read-only filesystem).\n`,
+      );
+      stderr.write(
+        `if HOME is sandboxed, point the cli at a writable directory:\n`,
+      );
+      stderr.write(`  HOME=$(mktemp -d) npx token-burner ...\n`);
+      return false;
+    }
+    throw error;
+  }
+};
+
 export const runRegisterCommand = async ({
   args,
   io,
@@ -32,6 +66,7 @@ export const runRegisterCommand = async ({
   let avatar: string;
   let agentLabel: string;
   let baseUrl: string;
+  let overwrite: boolean;
   try {
     const { flags } = parseArgs(args);
     claimCode = requireFlag(flags, "claim-code");
@@ -39,15 +74,37 @@ export const runRegisterCommand = async ({
     avatar = requireFlag(flags, "avatar");
     agentLabel = requireFlag(flags, "agent-label");
     baseUrl = flags["base-url"] ?? defaultBaseUrl;
+    overwrite = flags.overwrite !== undefined;
   } catch (error) {
     if (error instanceof CliArgsError) {
       stderr.write(`${error.message}\n`);
       stderr.write(
-        "usage: token-burner register --claim-code CODE --handle NAME --avatar X --agent-label LABEL [--base-url URL]\n",
+        "usage: token-burner register --claim-code CODE --handle NAME --avatar X --agent-label LABEL [--base-url URL] [--overwrite]\n",
       );
       return 2;
     }
     throw error;
+  }
+
+  if (!overwrite) {
+    const existing = await loadLocalConfig({ homeDir });
+    if (existing) {
+      const path = getLocalConfigPath({ homeDir });
+      const handleSummary = existing.publicHandle
+        ? ` for handle "${existing.publicHandle}"`
+        : "";
+      stderr.write(
+        `local token-burner config already exists at ${path}${handleSummary}.\n`,
+      );
+      stderr.write(
+        "to add this installation to that identity instead, run:\n",
+      );
+      stderr.write(`  npx token-burner link --agent-label ${agentLabel}\n`);
+      stderr.write(
+        "to wipe the existing identity and register a new one, re-run with --overwrite.\n",
+      );
+      return 1;
+    }
   }
 
   try {
@@ -64,7 +121,9 @@ export const runRegisterCommand = async ({
       publicHandle: response.handle,
       avatar: response.avatar,
     };
-    await saveLocalConfig(config, { homeDir });
+    if (!(await writeConfigOrReportPermission(config, homeDir, stderr))) {
+      return 1;
+    }
 
     stdout.write(
       `registered as ${response.handle} ${response.avatar} (${response.humanId})\n`,

--- a/packages/agent-cli/src/providers/anthropic.ts
+++ b/packages/agent-cli/src/providers/anthropic.ts
@@ -10,13 +10,12 @@ import type {
   ProviderCredentials,
 } from "./types.js";
 
-const anthropicModel = providerFlagshipModels.anthropic;
-
 const burnPrompt =
   "Produce a long stream of plausible-sounding lorem ipsum filler text. Do not ask questions or request clarification. Keep generating until you are told to stop.";
 
 export const createAnthropicAdapter = (
   credentials: ProviderCredentials,
+  model: string = providerFlagshipModels.anthropic,
 ): ProviderAdapter => {
   if (credentials.providerId !== "anthropic") {
     throw new Error(
@@ -31,10 +30,10 @@ export const createAnthropicAdapter = (
 
   return {
     providerId: "anthropic",
-    model: anthropicModel,
+    model,
     runBurnStep: async ({ maxOutputTokens }: BurnStepRequest): Promise<BurnStepResult> => {
       const response = await client.messages.create({
-        model: anthropicModel,
+        model,
         max_tokens: maxOutputTokens,
         messages: [{ role: "user", content: burnPrompt }],
       });

--- a/packages/agent-cli/src/providers/key-format.ts
+++ b/packages/agent-cli/src/providers/key-format.ts
@@ -1,0 +1,43 @@
+import type { ProviderId } from "@token-burner/shared";
+
+import { isInniesKey } from "./innies.js";
+
+export class ProviderKeyFormatError extends Error {
+  readonly providerId: ProviderId;
+
+  constructor(providerId: ProviderId, apiKey: string) {
+    const expected =
+      providerId === "openai"
+        ? '"sk-..." (or "in_live_..." / "in_test_..." for innies)'
+        : '"sk-ant-..." (or "in_live_..." / "in_test_..." for innies)';
+    const envVar =
+      providerId === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
+    const preview = apiKey.slice(0, 8);
+    super(
+      [
+        `${providerId} key format looks wrong.`,
+        `${envVar} (or --api-key) should start with ${expected}; yours starts with "${preview}".`,
+        `did you put a key for the other provider in the wrong slot?`,
+      ].join("\n"),
+    );
+    this.name = "ProviderKeyFormatError";
+    this.providerId = providerId;
+  }
+}
+
+export const validateProviderKeyFormat = (
+  providerId: ProviderId,
+  apiKey: string,
+): void => {
+  if (isInniesKey(apiKey)) {
+    return;
+  }
+  if (providerId === "openai") {
+    if (!apiKey.startsWith("sk-") || apiKey.startsWith("sk-ant-")) {
+      throw new ProviderKeyFormatError(providerId, apiKey);
+    }
+  }
+  if (providerId === "anthropic" && !apiKey.startsWith("sk-ant-")) {
+    throw new ProviderKeyFormatError(providerId, apiKey);
+  }
+};

--- a/packages/agent-cli/src/providers/openai.ts
+++ b/packages/agent-cli/src/providers/openai.ts
@@ -10,13 +10,12 @@ import type {
   ProviderCredentials,
 } from "./types.js";
 
-const openaiModel = providerFlagshipModels.openai;
-
 const burnPrompt =
   "Produce a long stream of plausible-sounding lorem ipsum filler text. Do not ask questions or request clarification. Keep generating until you are told to stop.";
 
 export const createOpenAIAdapter = (
   credentials: ProviderCredentials,
+  model: string = providerFlagshipModels.openai,
 ): ProviderAdapter => {
   if (credentials.providerId !== "openai") {
     throw new Error(
@@ -31,10 +30,10 @@ export const createOpenAIAdapter = (
 
   return {
     providerId: "openai",
-    model: openaiModel,
+    model,
     runBurnStep: async ({ maxOutputTokens }: BurnStepRequest): Promise<BurnStepResult> => {
       const response = await client.chat.completions.create({
-        model: openaiModel,
+        model,
         max_completion_tokens: maxOutputTokens,
         messages: [{ role: "user", content: burnPrompt }],
       });

--- a/packages/agent-cli/src/providers/select-model.ts
+++ b/packages/agent-cli/src/providers/select-model.ts
@@ -1,0 +1,70 @@
+import { providerModelFallbacks, type ProviderId } from "@token-burner/shared";
+
+import type { ProviderAdapter, ProviderCredentials } from "./types.js";
+
+export type AdapterFactory = (
+  credentials: ProviderCredentials,
+  model: string,
+) => ProviderAdapter;
+
+const isModelAvailabilityError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const status = (error as { status?: unknown }).status;
+  return status === 403 || status === 404;
+};
+
+export class NoAvailableModelError extends Error {
+  readonly tried: readonly string[];
+  readonly lastError: unknown;
+
+  constructor(provider: ProviderId, tried: readonly string[], lastError: unknown) {
+    super(
+      `no ${provider} model from this account's allowlist worked. tried: ${tried.join(", ")}. pass --model <id> with one your account can call.`,
+    );
+    this.name = "NoAvailableModelError";
+    this.tried = tried;
+    this.lastError = lastError;
+  }
+}
+
+// Picks a model the credentials can actually call. If `requestedModel` is
+// passed, returns it without probing — explicit user choice wins. Otherwise
+// probes the fallback chain for the provider with a 1-token request and
+// returns the first model that doesn't 403/404.
+export const selectAvailableModel = async ({
+  credentials,
+  requestedModel,
+  adapterFactory,
+}: {
+  credentials: ProviderCredentials;
+  requestedModel?: string;
+  adapterFactory: AdapterFactory;
+}): Promise<string> => {
+  if (requestedModel) {
+    return requestedModel;
+  }
+
+  const candidates = providerModelFallbacks[credentials.providerId];
+  let lastError: unknown = null;
+
+  for (const candidate of candidates) {
+    const adapter = adapterFactory(credentials, candidate);
+    try {
+      await adapter.runBurnStep({ maxOutputTokens: 1 });
+      return candidate;
+    } catch (error) {
+      lastError = error;
+      if (!isModelAvailabilityError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  throw new NoAvailableModelError(
+    credentials.providerId,
+    candidates,
+    lastError,
+  );
+};

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -31,3 +31,16 @@ export const providerFlagshipModels: Record<ProviderId, string> = {
   openai: "gpt-5.4",
   anthropic: "claude-opus-4-7",
 };
+
+// Ordered most-capable → most-widely-available. The cli probes in this
+// order when no --model flag is passed and falls back on 403/404 model
+// availability errors (e.g. proxied keys whose upstream account lacks
+// the flagship model).
+export const providerModelFallbacks: Record<ProviderId, readonly string[]> = {
+  openai: ["gpt-5.4", "gpt-5", "gpt-4o", "gpt-4o-mini"],
+  anthropic: [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+  ],
+};

--- a/tests/integration/server-auth-housekeeping.test.ts
+++ b/tests/integration/server-auth-housekeeping.test.ts
@@ -497,11 +497,12 @@ describe("server auth and housekeeping helpers", () => {
       avatarUrl: "https://example.com/finn.png",
     });
 
-    const freshStartedAt = new Date("2026-04-21T11:58:30.000Z");
+    // 30s before fixedNow — well inside the 60s stale window.
+    const freshStartedAt = new Date("2026-04-21T11:59:30.000Z");
     const freshBurn = await seedBurn(database, {
       ...human,
       status: "running",
-      createdAt: new Date("2026-04-21T11:40:00.000Z"),
+      createdAt: new Date("2026-04-21T11:59:30.000Z"),
       startedAt: freshStartedAt,
       lastHeartbeatAt: null,
     });
@@ -546,8 +547,9 @@ describe("server auth and housekeeping helpers", () => {
     await seedBurn(database, {
       ...human,
       status: "running",
-      createdAt: new Date("2026-04-21T11:55:00.000Z"),
-      lastHeartbeatAt: new Date("2026-04-21T11:59:00.000Z"),
+      createdAt: new Date("2026-04-21T11:59:00.000Z"),
+      // 15s before fixedNow — fresh per the 60s stale window.
+      lastHeartbeatAt: new Date("2026-04-21T11:59:45.000Z"),
     });
 
     const { ensureNoActiveBurnConflict } = await import(

--- a/tests/unit/agent-cli-burn.test.ts
+++ b/tests/unit/agent-cli-burn.test.ts
@@ -215,7 +215,7 @@ describe("runBurnCommand", () => {
     const stderr = streams.collected().stderr;
     expect(stderr).toContain("missing required flag");
     expect(stderr).toContain(
-      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--api-key KEY] [--base-url URL]",
+      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--model ID] [--api-key KEY] [--base-url URL]",
     );
   });
 
@@ -226,7 +226,10 @@ describe("runBurnCommand", () => {
       args: ["--provider", "anthropic", "--target", "100"],
       io: { stdout: streams.stdout, stderr: streams.stderr },
       homeDir,
-      credentialsResolver: () => ({ providerId: "anthropic", apiKey: "k" }),
+      credentialsResolver: () => ({
+        providerId: "anthropic",
+        apiKey: "sk-ant-test",
+      }),
       adapterFactory: () => buildFakeAdapter({ input: 1, output: 1 }),
       disableParentWatch: true,
     });
@@ -302,7 +305,10 @@ describe("runBurnCommand", () => {
       io: { stdout: streams.stdout, stderr: streams.stderr },
       fetchImpl: fetchImpl as unknown as typeof fetch,
       homeDir,
-      credentialsResolver: () => ({ providerId: "anthropic", apiKey: "k" }),
+      credentialsResolver: () => ({
+        providerId: "anthropic",
+        apiKey: "sk-ant-test",
+      }),
       adapterFactory: () => buildFakeAdapter({ input: 50, output: 4_000 }),
       disableParentWatch: true,
     });

--- a/tests/unit/agent-cli-commands.test.ts
+++ b/tests/unit/agent-cli-commands.test.ts
@@ -320,7 +320,7 @@ describe("agent cli top-level help", () => {
 
     expect(exitCode).toBe(0);
     expect(writes.stdout()).toContain(
-      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--api-key KEY] [--base-url URL]",
+      "token-burner burn --provider <openai|anthropic> (--target N | --preset tier-1|tier-2|tier-3) [--model ID] [--api-key KEY] [--base-url URL]",
     );
     expect(writes.stdout()).toContain("Use exactly one of --target or --preset.");
     expect(writes.stdout()).toContain("tier-1 Amuse-Bouche");

--- a/tests/unit/key-format.test.ts
+++ b/tests/unit/key-format.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ProviderKeyFormatError,
+  validateProviderKeyFormat,
+} from "../../packages/agent-cli/src/providers/key-format";
+
+describe("validateProviderKeyFormat", () => {
+  it("accepts real openai keys", () => {
+    expect(() =>
+      validateProviderKeyFormat("openai", "sk-proj-abc123"),
+    ).not.toThrow();
+    expect(() =>
+      validateProviderKeyFormat("openai", "sk-svcacct-xyz"),
+    ).not.toThrow();
+  });
+
+  it("accepts real anthropic keys", () => {
+    expect(() =>
+      validateProviderKeyFormat("anthropic", "sk-ant-api03-abc"),
+    ).not.toThrow();
+  });
+
+  it("accepts innies keys for either provider", () => {
+    expect(() =>
+      validateProviderKeyFormat("openai", "in_live_abc123"),
+    ).not.toThrow();
+    expect(() =>
+      validateProviderKeyFormat("anthropic", "in_live_abc123"),
+    ).not.toThrow();
+    expect(() =>
+      validateProviderKeyFormat("openai", "in_test_abc123"),
+    ).not.toThrow();
+  });
+
+  it("rejects an anthropic-shaped key in the openai slot", () => {
+    expect(() =>
+      validateProviderKeyFormat("openai", "sk-ant-api03-abc"),
+    ).toThrow(ProviderKeyFormatError);
+  });
+
+  it("rejects an openai-shaped key in the anthropic slot", () => {
+    expect(() =>
+      validateProviderKeyFormat("anthropic", "sk-proj-abc123"),
+    ).toThrow(ProviderKeyFormatError);
+  });
+
+  it("rejects garbage", () => {
+    expect(() => validateProviderKeyFormat("openai", "hunter2")).toThrow(
+      ProviderKeyFormatError,
+    );
+  });
+});

--- a/tests/unit/select-model.test.ts
+++ b/tests/unit/select-model.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  NoAvailableModelError,
+  selectAvailableModel,
+} from "../../packages/agent-cli/src/providers/select-model";
+import type { ProviderAdapter } from "../../packages/agent-cli/src/providers/types";
+
+const buildAdapter = (
+  model: string,
+  runBurnStep: ProviderAdapter["runBurnStep"],
+): ProviderAdapter => ({
+  providerId: "openai",
+  model,
+  runBurnStep,
+});
+
+const httpError = (status: number) => Object.assign(new Error("upstream"), {
+  status,
+});
+
+describe("selectAvailableModel", () => {
+  it("returns the requested model verbatim, no probing", async () => {
+    const factory = vi.fn();
+    const result = await selectAvailableModel({
+      credentials: { providerId: "openai", apiKey: "sk-test" },
+      requestedModel: "gpt-explicit",
+      adapterFactory: factory,
+    });
+    expect(result).toBe("gpt-explicit");
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("returns the first model in the fallback chain that does not 403/404", async () => {
+    let callIndex = 0;
+    const factory = vi.fn(
+      (_creds, model: string): ProviderAdapter =>
+        buildAdapter(model, async () => {
+          callIndex += 1;
+          if (callIndex === 1) throw httpError(403);
+          if (callIndex === 2) throw httpError(404);
+          return {
+            inputTokens: 1,
+            outputTokens: 1,
+            totalBilledTokens: 2,
+            stopReason: null,
+          };
+        }),
+    );
+
+    const result = await selectAvailableModel({
+      credentials: { providerId: "openai", apiKey: "sk-test" },
+      adapterFactory: factory,
+    });
+
+    expect(result).toBe("gpt-4o");
+    expect(factory).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows a non-availability error so we don't burn the chain on auth failures", async () => {
+    const factory = vi.fn((_creds, model: string): ProviderAdapter =>
+      buildAdapter(model, async () => {
+        throw httpError(401);
+      }),
+    );
+
+    await expect(
+      selectAvailableModel({
+        credentials: { providerId: "openai", apiKey: "sk-test" },
+        adapterFactory: factory,
+      }),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws NoAvailableModelError when every fallback 403/404s", async () => {
+    const factory = vi.fn((_creds, model: string): ProviderAdapter =>
+      buildAdapter(model, async () => {
+        throw httpError(403);
+      }),
+    );
+
+    await expect(
+      selectAvailableModel({
+        credentials: { providerId: "anthropic", apiKey: "sk-ant-test" },
+        adapterFactory: factory,
+      }),
+    ).rejects.toBeInstanceOf(NoAvailableModelError);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the realistic edge cases caught while testing net-new-agent onboarding:

| # | Issue | Fix |
|---|-------|-----|
| 1 | hardcoded \`gpt-5.4\` 403s on accounts without that model | \`--model\` flag + per-provider fallback chain (probe 1 token, lock in first model that works) |
| 2 | \`register\` silently overwrote existing config (you experienced this with \`shirtless\` → \`idiot\`) | refuse if config exists; tell agent to run \`link\` instead; \`--overwrite\` to opt out |
| 6 | crashed cli locked the human out for 5 min | stale-burn sweep timeout 5min → 60s |
| 7 | wrong-provider key (e.g. \`sk-ant-…\` in \`OPENAI_API_KEY\`) silently 401'd | prefix validation with a helpful error |
| 9 | read-only \`HOME\` bubbled raw \`EACCES\` | catch and surface a HOME-redirect hint |

CLI → 0.1.5.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint -w @token-burner/site\` clean
- [x] \`npm test\` → 83 / 83 (added: select-model 4 cases, key-format 6 cases; updated 2 stale-fixture timestamps + usage-string assertions for new \`[--model ID]\`)
- [ ] After \`npm publish\`: \`npx token-burner burn --provider openai --target 5k\` probes through the chain on a non-flagship account.
- [ ] Re-running \`register\` with an existing config refuses with a link suggestion.
- [ ] \`npx token-burner burn --provider openai\` with \`OPENAI_API_KEY=sk-ant-...\` errors with the format hint instead of 401.

## Note on take-effect
- Site changes (skill.md, housekeeping timeout) deploy via vercel on merge.
- CLI changes need \`npm publish\` from \`packages/agent-cli/\` to reach \`npx\` users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)